### PR TITLE
BUG/MEDIUM: runtime: Strip unix@ from master cli socket

### DIFF
--- a/configure_data_plane.go
+++ b/configure_data_plane.go
@@ -97,7 +97,7 @@ func configureAPI(api *operations.DataPlaneAPI) http.Handler {
 		mWorker = true
 		masterRuntime := os.Getenv("HAPROXY_MASTER_CLI")
 		if misc.IsUnixSocketAddr(masterRuntime) {
-			haproxyOptions.MasterRuntime = masterRuntime
+			haproxyOptions.MasterRuntime = strings.Replace(masterRuntime, "unix@", "", 1)
 		}
 	}
 	cfgFiles := os.Getenv("HAPROXY_CFGFILES")


### PR DESCRIPTION
When the master cli is configured as a unix socket HAProxy is sending
the path to the master cli as "unix@/path/to/master.sock" within the
environment variable HAPROXY_MASTER_CLI. The Data Plane API is then
trying to take this string and connect to it without stripping the 'unix@'
portion off. This causes an error during connect() as seen in the below strace:

[pid 17968] connect(14, {sa_family=AF_UNIX, sun_path="unix@/tmp/master.sock"}, 24) = -1 ENOENT (No such file or directory)

This should be the path only "/tmp/master.sock" and not "unix@/tmp/master.sock".

This issue was also referenced in #50 but the work around ended up being
to remove use of the master cli completely.

This commit fixes the underlying issue and strips 'unix@' from the socket
path allowing for the master cli to be used.