### PR TITLE
BUG/MAJOR: discovery: Add type assertion check to DiscoverChildPaths

### DIFF
--- a/misc/misc.go
+++ b/misc/misc.go
@@ -76,18 +76,19 @@ func DiscoverChildPaths(path string, spec json.RawMessage) (models.Endpoints, er
 	paths := m["paths"].(map[string]interface{})
 	for key, value := range paths {
 		v := value.(map[string]interface{})
-		g := v["get"].(map[string]interface{})
-		title := g["summary"].(string)
-		description := g["description"].(string)
+		if g, ok := v["get"].(map[string]interface{}); ok {
+			title := g["summary"].(string)
+			description := g["description"].(string)
 
-		if strings.HasPrefix(key, path) && key != path {
-			if len(strings.Split(key[len(path)+1:], "/")) == 1 {
-				e := models.Endpoint{
-					URL:         key,
-					Title:       title,
-					Description: description,
+			if strings.HasPrefix(key, path) && key != path {
+				if len(strings.Split(key[len(path)+1:], "/")) == 1 {
+					e := models.Endpoint{
+						URL:         key,
+						Title:       title,
+						Description: description,
+					}
+					es = append(es, &e)
 				}
-				es = append(es, &e)
 			}
 		}
 	}


### PR DESCRIPTION
A panic is caused when DiscoverChildPaths loops over endpoints that
do not have a "get" method defined within embedded_spec.go. At time of
this commit it is caused specifically by "/cluster/certificate" only
having "post" and not a "get" defined. This commit adds a type assertion
check to verify that v["get"] is of type map[string]interface{}.

This fixes #85