### PR TITLE
BUG: Prevent a panic in the case when a map only has 1 entry

### DIFF
--- a/configure_data_plane.go
+++ b/configure_data_plane.go
@@ -795,7 +795,7 @@ func equalSomeFileAndRuntimeEntries(fEntries, rEntries models.MapEntries) bool {
 
 	for i := 0; i < 10; i++ {
 		rand.Seed(time.Now().UTC().UnixNano())
-		r := rand.Intn(max-1) + 1
+		r := rand.Intn(max)
 		if rEntries[r].Key != fEntries[r].Key || rEntries[r].Value != fEntries[r].Value {
 			return false
 		}


### PR DESCRIPTION
When a map only has a single entry `rand.Intn()` is supplied with `0` as
as parameter which is invalid.

In addition the previous code included a `+ 1` to the result of `rand.Intn()`.
This is not needed, `rand.Intn()` provides results in the range of 0-(n-1)
which will align with the array indexes.