### PR TITLE
Fixes for changes in go-openapi/errors v0.19.6

### DIFF
--- a/operations/acl/create_acl_parameters.go
+++ b/operations/acl/create_acl_parameters.go
@@ -104,7 +104,7 @@ func (o *CreateACLParams) BindRequest(r *http.Request, route *middleware.Matched
 		var body models.ACL
 		if err := route.Consumer.Consume(r.Body, &body); err != nil {
 			if err == io.EOF {
-				res = append(res, errors.Required("data", "body"))
+				res = append(res, errors.Required("data", "body", ""))
 			} else {
 				res = append(res, errors.NewParseError("data", "body", "", err))
 			}
@@ -119,7 +119,7 @@ func (o *CreateACLParams) BindRequest(r *http.Request, route *middleware.Matched
 			}
 		}
 	} else {
-		res = append(res, errors.Required("data", "body"))
+		res = append(res, errors.Required("data", "body", ""))
 	}
 	qForceReload, qhkForceReload, _ := qs.GetOK("force_reload")
 	if err := o.bindForceReload(qForceReload, qhkForceReload, route.Formats); err != nil {
@@ -178,7 +178,7 @@ func (o *CreateACLParams) bindForceReload(rawData []string, hasKey bool, formats
 // bindParentName binds and validates parameter ParentName from query.
 func (o *CreateACLParams) bindParentName(rawData []string, hasKey bool, formats strfmt.Registry) error {
 	if !hasKey {
-		return errors.Required("parent_name", "query")
+		return errors.Required("parent_name", "query", "")
 	}
 	var raw string
 	if len(rawData) > 0 {
@@ -199,7 +199,7 @@ func (o *CreateACLParams) bindParentName(rawData []string, hasKey bool, formats 
 // bindParentType binds and validates parameter ParentType from query.
 func (o *CreateACLParams) bindParentType(rawData []string, hasKey bool, formats strfmt.Registry) error {
 	if !hasKey {
-		return errors.Required("parent_type", "query")
+		return errors.Required("parent_type", "query", "")
 	}
 	var raw string
 	if len(rawData) > 0 {

--- a/operations/acl/delete_acl_parameters.go
+++ b/operations/acl/delete_acl_parameters.go
@@ -177,7 +177,7 @@ func (o *DeleteACLParams) bindIndex(rawData []string, hasKey bool, formats strfm
 // bindParentName binds and validates parameter ParentName from query.
 func (o *DeleteACLParams) bindParentName(rawData []string, hasKey bool, formats strfmt.Registry) error {
 	if !hasKey {
-		return errors.Required("parent_name", "query")
+		return errors.Required("parent_name", "query", "")
 	}
 	var raw string
 	if len(rawData) > 0 {
@@ -198,7 +198,7 @@ func (o *DeleteACLParams) bindParentName(rawData []string, hasKey bool, formats 
 // bindParentType binds and validates parameter ParentType from query.
 func (o *DeleteACLParams) bindParentType(rawData []string, hasKey bool, formats strfmt.Registry) error {
 	if !hasKey {
-		return errors.Required("parent_type", "query")
+		return errors.Required("parent_type", "query", "")
 	}
 	var raw string
 	if len(rawData) > 0 {

--- a/operations/acl/get_acl_parameters.go
+++ b/operations/acl/get_acl_parameters.go
@@ -127,7 +127,7 @@ func (o *GetACLParams) bindIndex(rawData []string, hasKey bool, formats strfmt.R
 // bindParentName binds and validates parameter ParentName from query.
 func (o *GetACLParams) bindParentName(rawData []string, hasKey bool, formats strfmt.Registry) error {
 	if !hasKey {
-		return errors.Required("parent_name", "query")
+		return errors.Required("parent_name", "query", "")
 	}
 	var raw string
 	if len(rawData) > 0 {
@@ -148,7 +148,7 @@ func (o *GetACLParams) bindParentName(rawData []string, hasKey bool, formats str
 // bindParentType binds and validates parameter ParentType from query.
 func (o *GetACLParams) bindParentType(rawData []string, hasKey bool, formats strfmt.Registry) error {
 	if !hasKey {
-		return errors.Required("parent_type", "query")
+		return errors.Required("parent_type", "query", "")
 	}
 	var raw string
 	if len(rawData) > 0 {

--- a/operations/acl/get_acls_parameters.go
+++ b/operations/acl/get_acls_parameters.go
@@ -97,7 +97,7 @@ func (o *GetAclsParams) BindRequest(r *http.Request, route *middleware.MatchedRo
 // bindParentName binds and validates parameter ParentName from query.
 func (o *GetAclsParams) bindParentName(rawData []string, hasKey bool, formats strfmt.Registry) error {
 	if !hasKey {
-		return errors.Required("parent_name", "query")
+		return errors.Required("parent_name", "query", "")
 	}
 	var raw string
 	if len(rawData) > 0 {
@@ -118,7 +118,7 @@ func (o *GetAclsParams) bindParentName(rawData []string, hasKey bool, formats st
 // bindParentType binds and validates parameter ParentType from query.
 func (o *GetAclsParams) bindParentType(rawData []string, hasKey bool, formats strfmt.Registry) error {
 	if !hasKey {
-		return errors.Required("parent_type", "query")
+		return errors.Required("parent_type", "query", "")
 	}
 	var raw string
 	if len(rawData) > 0 {

--- a/operations/acl/replace_acl_parameters.go
+++ b/operations/acl/replace_acl_parameters.go
@@ -109,7 +109,7 @@ func (o *ReplaceACLParams) BindRequest(r *http.Request, route *middleware.Matche
 		var body models.ACL
 		if err := route.Consumer.Consume(r.Body, &body); err != nil {
 			if err == io.EOF {
-				res = append(res, errors.Required("data", "body"))
+				res = append(res, errors.Required("data", "body", ""))
 			} else {
 				res = append(res, errors.NewParseError("data", "body", "", err))
 			}
@@ -124,7 +124,7 @@ func (o *ReplaceACLParams) BindRequest(r *http.Request, route *middleware.Matche
 			}
 		}
 	} else {
-		res = append(res, errors.Required("data", "body"))
+		res = append(res, errors.Required("data", "body", ""))
 	}
 	qForceReload, qhkForceReload, _ := qs.GetOK("force_reload")
 	if err := o.bindForceReload(qForceReload, qhkForceReload, route.Formats); err != nil {
@@ -207,7 +207,7 @@ func (o *ReplaceACLParams) bindIndex(rawData []string, hasKey bool, formats strf
 // bindParentName binds and validates parameter ParentName from query.
 func (o *ReplaceACLParams) bindParentName(rawData []string, hasKey bool, formats strfmt.Registry) error {
 	if !hasKey {
-		return errors.Required("parent_name", "query")
+		return errors.Required("parent_name", "query", "")
 	}
 	var raw string
 	if len(rawData) > 0 {
@@ -228,7 +228,7 @@ func (o *ReplaceACLParams) bindParentName(rawData []string, hasKey bool, formats
 // bindParentType binds and validates parameter ParentType from query.
 func (o *ReplaceACLParams) bindParentType(rawData []string, hasKey bool, formats strfmt.Registry) error {
 	if !hasKey {
-		return errors.Required("parent_type", "query")
+		return errors.Required("parent_type", "query", "")
 	}
 	var raw string
 	if len(rawData) > 0 {

--- a/operations/backend/create_backend_parameters.go
+++ b/operations/backend/create_backend_parameters.go
@@ -93,7 +93,7 @@ func (o *CreateBackendParams) BindRequest(r *http.Request, route *middleware.Mat
 		var body models.Backend
 		if err := route.Consumer.Consume(r.Body, &body); err != nil {
 			if err == io.EOF {
-				res = append(res, errors.Required("data", "body"))
+				res = append(res, errors.Required("data", "body", ""))
 			} else {
 				res = append(res, errors.NewParseError("data", "body", "", err))
 			}
@@ -108,7 +108,7 @@ func (o *CreateBackendParams) BindRequest(r *http.Request, route *middleware.Mat
 			}
 		}
 	} else {
-		res = append(res, errors.Required("data", "body"))
+		res = append(res, errors.Required("data", "body", ""))
 	}
 	qForceReload, qhkForceReload, _ := qs.GetOK("force_reload")
 	if err := o.bindForceReload(qForceReload, qhkForceReload, route.Formats); err != nil {

--- a/operations/backend/replace_backend_parameters.go
+++ b/operations/backend/replace_backend_parameters.go
@@ -98,7 +98,7 @@ func (o *ReplaceBackendParams) BindRequest(r *http.Request, route *middleware.Ma
 		var body models.Backend
 		if err := route.Consumer.Consume(r.Body, &body); err != nil {
 			if err == io.EOF {
-				res = append(res, errors.Required("data", "body"))
+				res = append(res, errors.Required("data", "body", ""))
 			} else {
 				res = append(res, errors.NewParseError("data", "body", "", err))
 			}
@@ -113,7 +113,7 @@ func (o *ReplaceBackendParams) BindRequest(r *http.Request, route *middleware.Ma
 			}
 		}
 	} else {
-		res = append(res, errors.Required("data", "body"))
+		res = append(res, errors.Required("data", "body", ""))
 	}
 	qForceReload, qhkForceReload, _ := qs.GetOK("force_reload")
 	if err := o.bindForceReload(qForceReload, qhkForceReload, route.Formats); err != nil {

--- a/operations/backend_switching_rule/create_backend_switching_rule_parameters.go
+++ b/operations/backend_switching_rule/create_backend_switching_rule_parameters.go
@@ -99,7 +99,7 @@ func (o *CreateBackendSwitchingRuleParams) BindRequest(r *http.Request, route *m
 		var body models.BackendSwitchingRule
 		if err := route.Consumer.Consume(r.Body, &body); err != nil {
 			if err == io.EOF {
-				res = append(res, errors.Required("data", "body"))
+				res = append(res, errors.Required("data", "body", ""))
 			} else {
 				res = append(res, errors.NewParseError("data", "body", "", err))
 			}
@@ -114,7 +114,7 @@ func (o *CreateBackendSwitchingRuleParams) BindRequest(r *http.Request, route *m
 			}
 		}
 	} else {
-		res = append(res, errors.Required("data", "body"))
+		res = append(res, errors.Required("data", "body", ""))
 	}
 	qForceReload, qhkForceReload, _ := qs.GetOK("force_reload")
 	if err := o.bindForceReload(qForceReload, qhkForceReload, route.Formats); err != nil {
@@ -168,7 +168,7 @@ func (o *CreateBackendSwitchingRuleParams) bindForceReload(rawData []string, has
 // bindFrontend binds and validates parameter Frontend from query.
 func (o *CreateBackendSwitchingRuleParams) bindFrontend(rawData []string, hasKey bool, formats strfmt.Registry) error {
 	if !hasKey {
-		return errors.Required("frontend", "query")
+		return errors.Required("frontend", "query", "")
 	}
 	var raw string
 	if len(rawData) > 0 {

--- a/operations/backend_switching_rule/delete_backend_switching_rule_parameters.go
+++ b/operations/backend_switching_rule/delete_backend_switching_rule_parameters.go
@@ -148,7 +148,7 @@ func (o *DeleteBackendSwitchingRuleParams) bindForceReload(rawData []string, has
 // bindFrontend binds and validates parameter Frontend from query.
 func (o *DeleteBackendSwitchingRuleParams) bindFrontend(rawData []string, hasKey bool, formats strfmt.Registry) error {
 	if !hasKey {
-		return errors.Required("frontend", "query")
+		return errors.Required("frontend", "query", "")
 	}
 	var raw string
 	if len(rawData) > 0 {

--- a/operations/backend_switching_rule/get_backend_switching_rule_parameters.go
+++ b/operations/backend_switching_rule/get_backend_switching_rule_parameters.go
@@ -98,7 +98,7 @@ func (o *GetBackendSwitchingRuleParams) BindRequest(r *http.Request, route *midd
 // bindFrontend binds and validates parameter Frontend from query.
 func (o *GetBackendSwitchingRuleParams) bindFrontend(rawData []string, hasKey bool, formats strfmt.Registry) error {
 	if !hasKey {
-		return errors.Required("frontend", "query")
+		return errors.Required("frontend", "query", "")
 	}
 	var raw string
 	if len(rawData) > 0 {

--- a/operations/backend_switching_rule/get_backend_switching_rules_parameters.go
+++ b/operations/backend_switching_rule/get_backend_switching_rules_parameters.go
@@ -87,7 +87,7 @@ func (o *GetBackendSwitchingRulesParams) BindRequest(r *http.Request, route *mid
 // bindFrontend binds and validates parameter Frontend from query.
 func (o *GetBackendSwitchingRulesParams) bindFrontend(rawData []string, hasKey bool, formats strfmt.Registry) error {
 	if !hasKey {
-		return errors.Required("frontend", "query")
+		return errors.Required("frontend", "query", "")
 	}
 	var raw string
 	if len(rawData) > 0 {

--- a/operations/backend_switching_rule/replace_backend_switching_rule_parameters.go
+++ b/operations/backend_switching_rule/replace_backend_switching_rule_parameters.go
@@ -104,7 +104,7 @@ func (o *ReplaceBackendSwitchingRuleParams) BindRequest(r *http.Request, route *
 		var body models.BackendSwitchingRule
 		if err := route.Consumer.Consume(r.Body, &body); err != nil {
 			if err == io.EOF {
-				res = append(res, errors.Required("data", "body"))
+				res = append(res, errors.Required("data", "body", ""))
 			} else {
 				res = append(res, errors.NewParseError("data", "body", "", err))
 			}
@@ -119,7 +119,7 @@ func (o *ReplaceBackendSwitchingRuleParams) BindRequest(r *http.Request, route *
 			}
 		}
 	} else {
-		res = append(res, errors.Required("data", "body"))
+		res = append(res, errors.Required("data", "body", ""))
 	}
 	qForceReload, qhkForceReload, _ := qs.GetOK("force_reload")
 	if err := o.bindForceReload(qForceReload, qhkForceReload, route.Formats); err != nil {
@@ -178,7 +178,7 @@ func (o *ReplaceBackendSwitchingRuleParams) bindForceReload(rawData []string, ha
 // bindFrontend binds and validates parameter Frontend from query.
 func (o *ReplaceBackendSwitchingRuleParams) bindFrontend(rawData []string, hasKey bool, formats strfmt.Registry) error {
 	if !hasKey {
-		return errors.Required("frontend", "query")
+		return errors.Required("frontend", "query", "")
 	}
 	var raw string
 	if len(rawData) > 0 {

--- a/operations/bind/create_bind_parameters.go
+++ b/operations/bind/create_bind_parameters.go
@@ -99,7 +99,7 @@ func (o *CreateBindParams) BindRequest(r *http.Request, route *middleware.Matche
 		var body models.Bind
 		if err := route.Consumer.Consume(r.Body, &body); err != nil {
 			if err == io.EOF {
-				res = append(res, errors.Required("data", "body"))
+				res = append(res, errors.Required("data", "body", ""))
 			} else {
 				res = append(res, errors.NewParseError("data", "body", "", err))
 			}
@@ -114,7 +114,7 @@ func (o *CreateBindParams) BindRequest(r *http.Request, route *middleware.Matche
 			}
 		}
 	} else {
-		res = append(res, errors.Required("data", "body"))
+		res = append(res, errors.Required("data", "body", ""))
 	}
 	qForceReload, qhkForceReload, _ := qs.GetOK("force_reload")
 	if err := o.bindForceReload(qForceReload, qhkForceReload, route.Formats); err != nil {
@@ -168,7 +168,7 @@ func (o *CreateBindParams) bindForceReload(rawData []string, hasKey bool, format
 // bindFrontend binds and validates parameter Frontend from query.
 func (o *CreateBindParams) bindFrontend(rawData []string, hasKey bool, formats strfmt.Registry) error {
 	if !hasKey {
-		return errors.Required("frontend", "query")
+		return errors.Required("frontend", "query", "")
 	}
 	var raw string
 	if len(rawData) > 0 {

--- a/operations/bind/delete_bind_parameters.go
+++ b/operations/bind/delete_bind_parameters.go
@@ -148,7 +148,7 @@ func (o *DeleteBindParams) bindForceReload(rawData []string, hasKey bool, format
 // bindFrontend binds and validates parameter Frontend from query.
 func (o *DeleteBindParams) bindFrontend(rawData []string, hasKey bool, formats strfmt.Registry) error {
 	if !hasKey {
-		return errors.Required("frontend", "query")
+		return errors.Required("frontend", "query", "")
 	}
 	var raw string
 	if len(rawData) > 0 {

--- a/operations/bind/get_bind_parameters.go
+++ b/operations/bind/get_bind_parameters.go
@@ -97,7 +97,7 @@ func (o *GetBindParams) BindRequest(r *http.Request, route *middleware.MatchedRo
 // bindFrontend binds and validates parameter Frontend from query.
 func (o *GetBindParams) bindFrontend(rawData []string, hasKey bool, formats strfmt.Registry) error {
 	if !hasKey {
-		return errors.Required("frontend", "query")
+		return errors.Required("frontend", "query", "")
 	}
 	var raw string
 	if len(rawData) > 0 {

--- a/operations/bind/get_binds_parameters.go
+++ b/operations/bind/get_binds_parameters.go
@@ -87,7 +87,7 @@ func (o *GetBindsParams) BindRequest(r *http.Request, route *middleware.MatchedR
 // bindFrontend binds and validates parameter Frontend from query.
 func (o *GetBindsParams) bindFrontend(rawData []string, hasKey bool, formats strfmt.Registry) error {
 	if !hasKey {
-		return errors.Required("frontend", "query")
+		return errors.Required("frontend", "query", "")
 	}
 	var raw string
 	if len(rawData) > 0 {

--- a/operations/bind/replace_bind_parameters.go
+++ b/operations/bind/replace_bind_parameters.go
@@ -104,7 +104,7 @@ func (o *ReplaceBindParams) BindRequest(r *http.Request, route *middleware.Match
 		var body models.Bind
 		if err := route.Consumer.Consume(r.Body, &body); err != nil {
 			if err == io.EOF {
-				res = append(res, errors.Required("data", "body"))
+				res = append(res, errors.Required("data", "body", ""))
 			} else {
 				res = append(res, errors.NewParseError("data", "body", "", err))
 			}
@@ -119,7 +119,7 @@ func (o *ReplaceBindParams) BindRequest(r *http.Request, route *middleware.Match
 			}
 		}
 	} else {
-		res = append(res, errors.Required("data", "body"))
+		res = append(res, errors.Required("data", "body", ""))
 	}
 	qForceReload, qhkForceReload, _ := qs.GetOK("force_reload")
 	if err := o.bindForceReload(qForceReload, qhkForceReload, route.Formats); err != nil {
@@ -178,7 +178,7 @@ func (o *ReplaceBindParams) bindForceReload(rawData []string, hasKey bool, forma
 // bindFrontend binds and validates parameter Frontend from query.
 func (o *ReplaceBindParams) bindFrontend(rawData []string, hasKey bool, formats strfmt.Registry) error {
 	if !hasKey {
-		return errors.Required("frontend", "query")
+		return errors.Required("frontend", "query", "")
 	}
 	var raw string
 	if len(rawData) > 0 {

--- a/operations/cluster/post_cluster_parameters.go
+++ b/operations/cluster/post_cluster_parameters.go
@@ -86,7 +86,7 @@ func (o *PostClusterParams) BindRequest(r *http.Request, route *middleware.Match
 		var body models.ClusterSettings
 		if err := route.Consumer.Consume(r.Body, &body); err != nil {
 			if err == io.EOF {
-				res = append(res, errors.Required("data", "body"))
+				res = append(res, errors.Required("data", "body", ""))
 			} else {
 				res = append(res, errors.NewParseError("data", "body", "", err))
 			}
@@ -101,7 +101,7 @@ func (o *PostClusterParams) BindRequest(r *http.Request, route *middleware.Match
 			}
 		}
 	} else {
-		res = append(res, errors.Required("data", "body"))
+		res = append(res, errors.Required("data", "body", ""))
 	}
 	qVersion, qhkVersion, _ := qs.GetOK("version")
 	if err := o.bindVersion(qVersion, qhkVersion, route.Formats); err != nil {

--- a/operations/configuration/post_h_a_proxy_configuration_parameters.go
+++ b/operations/configuration/post_h_a_proxy_configuration_parameters.go
@@ -111,7 +111,7 @@ func (o *PostHAProxyConfigurationParams) BindRequest(r *http.Request, route *mid
 		var body string
 		if err := route.Consumer.Consume(r.Body, &body); err != nil {
 			if err == io.EOF {
-				res = append(res, errors.Required("data", "body"))
+				res = append(res, errors.Required("data", "body", ""))
 			} else {
 				res = append(res, errors.NewParseError("data", "body", "", err))
 			}
@@ -120,7 +120,7 @@ func (o *PostHAProxyConfigurationParams) BindRequest(r *http.Request, route *mid
 			o.Data = body
 		}
 	} else {
-		res = append(res, errors.Required("data", "body"))
+		res = append(res, errors.Required("data", "body", ""))
 	}
 	qForceReload, qhkForceReload, _ := qs.GetOK("force_reload")
 	if err := o.bindForceReload(qForceReload, qhkForceReload, route.Formats); err != nil {

--- a/operations/defaults/replace_defaults_parameters.go
+++ b/operations/defaults/replace_defaults_parameters.go
@@ -93,7 +93,7 @@ func (o *ReplaceDefaultsParams) BindRequest(r *http.Request, route *middleware.M
 		var body models.Defaults
 		if err := route.Consumer.Consume(r.Body, &body); err != nil {
 			if err == io.EOF {
-				res = append(res, errors.Required("data", "body"))
+				res = append(res, errors.Required("data", "body", ""))
 			} else {
 				res = append(res, errors.NewParseError("data", "body", "", err))
 			}
@@ -108,7 +108,7 @@ func (o *ReplaceDefaultsParams) BindRequest(r *http.Request, route *middleware.M
 			}
 		}
 	} else {
-		res = append(res, errors.Required("data", "body"))
+		res = append(res, errors.Required("data", "body", ""))
 	}
 	qForceReload, qhkForceReload, _ := qs.GetOK("force_reload")
 	if err := o.bindForceReload(qForceReload, qhkForceReload, route.Formats); err != nil {

--- a/operations/filter/create_filter_parameters.go
+++ b/operations/filter/create_filter_parameters.go
@@ -104,7 +104,7 @@ func (o *CreateFilterParams) BindRequest(r *http.Request, route *middleware.Matc
 		var body models.Filter
 		if err := route.Consumer.Consume(r.Body, &body); err != nil {
 			if err == io.EOF {
-				res = append(res, errors.Required("data", "body"))
+				res = append(res, errors.Required("data", "body", ""))
 			} else {
 				res = append(res, errors.NewParseError("data", "body", "", err))
 			}
@@ -119,7 +119,7 @@ func (o *CreateFilterParams) BindRequest(r *http.Request, route *middleware.Matc
 			}
 		}
 	} else {
-		res = append(res, errors.Required("data", "body"))
+		res = append(res, errors.Required("data", "body", ""))
 	}
 	qForceReload, qhkForceReload, _ := qs.GetOK("force_reload")
 	if err := o.bindForceReload(qForceReload, qhkForceReload, route.Formats); err != nil {
@@ -178,7 +178,7 @@ func (o *CreateFilterParams) bindForceReload(rawData []string, hasKey bool, form
 // bindParentName binds and validates parameter ParentName from query.
 func (o *CreateFilterParams) bindParentName(rawData []string, hasKey bool, formats strfmt.Registry) error {
 	if !hasKey {
-		return errors.Required("parent_name", "query")
+		return errors.Required("parent_name", "query", "")
 	}
 	var raw string
 	if len(rawData) > 0 {
@@ -199,7 +199,7 @@ func (o *CreateFilterParams) bindParentName(rawData []string, hasKey bool, forma
 // bindParentType binds and validates parameter ParentType from query.
 func (o *CreateFilterParams) bindParentType(rawData []string, hasKey bool, formats strfmt.Registry) error {
 	if !hasKey {
-		return errors.Required("parent_type", "query")
+		return errors.Required("parent_type", "query", "")
 	}
 	var raw string
 	if len(rawData) > 0 {

--- a/operations/filter/delete_filter_parameters.go
+++ b/operations/filter/delete_filter_parameters.go
@@ -177,7 +177,7 @@ func (o *DeleteFilterParams) bindIndex(rawData []string, hasKey bool, formats st
 // bindParentName binds and validates parameter ParentName from query.
 func (o *DeleteFilterParams) bindParentName(rawData []string, hasKey bool, formats strfmt.Registry) error {
 	if !hasKey {
-		return errors.Required("parent_name", "query")
+		return errors.Required("parent_name", "query", "")
 	}
 	var raw string
 	if len(rawData) > 0 {
@@ -198,7 +198,7 @@ func (o *DeleteFilterParams) bindParentName(rawData []string, hasKey bool, forma
 // bindParentType binds and validates parameter ParentType from query.
 func (o *DeleteFilterParams) bindParentType(rawData []string, hasKey bool, formats strfmt.Registry) error {
 	if !hasKey {
-		return errors.Required("parent_type", "query")
+		return errors.Required("parent_type", "query", "")
 	}
 	var raw string
 	if len(rawData) > 0 {

--- a/operations/filter/get_filter_parameters.go
+++ b/operations/filter/get_filter_parameters.go
@@ -127,7 +127,7 @@ func (o *GetFilterParams) bindIndex(rawData []string, hasKey bool, formats strfm
 // bindParentName binds and validates parameter ParentName from query.
 func (o *GetFilterParams) bindParentName(rawData []string, hasKey bool, formats strfmt.Registry) error {
 	if !hasKey {
-		return errors.Required("parent_name", "query")
+		return errors.Required("parent_name", "query", "")
 	}
 	var raw string
 	if len(rawData) > 0 {
@@ -148,7 +148,7 @@ func (o *GetFilterParams) bindParentName(rawData []string, hasKey bool, formats 
 // bindParentType binds and validates parameter ParentType from query.
 func (o *GetFilterParams) bindParentType(rawData []string, hasKey bool, formats strfmt.Registry) error {
 	if !hasKey {
-		return errors.Required("parent_type", "query")
+		return errors.Required("parent_type", "query", "")
 	}
 	var raw string
 	if len(rawData) > 0 {

--- a/operations/filter/get_filters_parameters.go
+++ b/operations/filter/get_filters_parameters.go
@@ -97,7 +97,7 @@ func (o *GetFiltersParams) BindRequest(r *http.Request, route *middleware.Matche
 // bindParentName binds and validates parameter ParentName from query.
 func (o *GetFiltersParams) bindParentName(rawData []string, hasKey bool, formats strfmt.Registry) error {
 	if !hasKey {
-		return errors.Required("parent_name", "query")
+		return errors.Required("parent_name", "query", "")
 	}
 	var raw string
 	if len(rawData) > 0 {
@@ -118,7 +118,7 @@ func (o *GetFiltersParams) bindParentName(rawData []string, hasKey bool, formats
 // bindParentType binds and validates parameter ParentType from query.
 func (o *GetFiltersParams) bindParentType(rawData []string, hasKey bool, formats strfmt.Registry) error {
 	if !hasKey {
-		return errors.Required("parent_type", "query")
+		return errors.Required("parent_type", "query", "")
 	}
 	var raw string
 	if len(rawData) > 0 {

--- a/operations/filter/replace_filter_parameters.go
+++ b/operations/filter/replace_filter_parameters.go
@@ -109,7 +109,7 @@ func (o *ReplaceFilterParams) BindRequest(r *http.Request, route *middleware.Mat
 		var body models.Filter
 		if err := route.Consumer.Consume(r.Body, &body); err != nil {
 			if err == io.EOF {
-				res = append(res, errors.Required("data", "body"))
+				res = append(res, errors.Required("data", "body", ""))
 			} else {
 				res = append(res, errors.NewParseError("data", "body", "", err))
 			}
@@ -124,7 +124,7 @@ func (o *ReplaceFilterParams) BindRequest(r *http.Request, route *middleware.Mat
 			}
 		}
 	} else {
-		res = append(res, errors.Required("data", "body"))
+		res = append(res, errors.Required("data", "body", ""))
 	}
 	qForceReload, qhkForceReload, _ := qs.GetOK("force_reload")
 	if err := o.bindForceReload(qForceReload, qhkForceReload, route.Formats); err != nil {
@@ -207,7 +207,7 @@ func (o *ReplaceFilterParams) bindIndex(rawData []string, hasKey bool, formats s
 // bindParentName binds and validates parameter ParentName from query.
 func (o *ReplaceFilterParams) bindParentName(rawData []string, hasKey bool, formats strfmt.Registry) error {
 	if !hasKey {
-		return errors.Required("parent_name", "query")
+		return errors.Required("parent_name", "query", "")
 	}
 	var raw string
 	if len(rawData) > 0 {
@@ -228,7 +228,7 @@ func (o *ReplaceFilterParams) bindParentName(rawData []string, hasKey bool, form
 // bindParentType binds and validates parameter ParentType from query.
 func (o *ReplaceFilterParams) bindParentType(rawData []string, hasKey bool, formats strfmt.Registry) error {
 	if !hasKey {
-		return errors.Required("parent_type", "query")
+		return errors.Required("parent_type", "query", "")
 	}
 	var raw string
 	if len(rawData) > 0 {

--- a/operations/frontend/create_frontend_parameters.go
+++ b/operations/frontend/create_frontend_parameters.go
@@ -93,7 +93,7 @@ func (o *CreateFrontendParams) BindRequest(r *http.Request, route *middleware.Ma
 		var body models.Frontend
 		if err := route.Consumer.Consume(r.Body, &body); err != nil {
 			if err == io.EOF {
-				res = append(res, errors.Required("data", "body"))
+				res = append(res, errors.Required("data", "body", ""))
 			} else {
 				res = append(res, errors.NewParseError("data", "body", "", err))
 			}
@@ -108,7 +108,7 @@ func (o *CreateFrontendParams) BindRequest(r *http.Request, route *middleware.Ma
 			}
 		}
 	} else {
-		res = append(res, errors.Required("data", "body"))
+		res = append(res, errors.Required("data", "body", ""))
 	}
 	qForceReload, qhkForceReload, _ := qs.GetOK("force_reload")
 	if err := o.bindForceReload(qForceReload, qhkForceReload, route.Formats); err != nil {

--- a/operations/frontend/replace_frontend_parameters.go
+++ b/operations/frontend/replace_frontend_parameters.go
@@ -98,7 +98,7 @@ func (o *ReplaceFrontendParams) BindRequest(r *http.Request, route *middleware.M
 		var body models.Frontend
 		if err := route.Consumer.Consume(r.Body, &body); err != nil {
 			if err == io.EOF {
-				res = append(res, errors.Required("data", "body"))
+				res = append(res, errors.Required("data", "body", ""))
 			} else {
 				res = append(res, errors.NewParseError("data", "body", "", err))
 			}
@@ -113,7 +113,7 @@ func (o *ReplaceFrontendParams) BindRequest(r *http.Request, route *middleware.M
 			}
 		}
 	} else {
-		res = append(res, errors.Required("data", "body"))
+		res = append(res, errors.Required("data", "body", ""))
 	}
 	qForceReload, qhkForceReload, _ := qs.GetOK("force_reload")
 	if err := o.bindForceReload(qForceReload, qhkForceReload, route.Formats); err != nil {

--- a/operations/global/replace_global_parameters.go
+++ b/operations/global/replace_global_parameters.go
@@ -93,7 +93,7 @@ func (o *ReplaceGlobalParams) BindRequest(r *http.Request, route *middleware.Mat
 		var body models.Global
 		if err := route.Consumer.Consume(r.Body, &body); err != nil {
 			if err == io.EOF {
-				res = append(res, errors.Required("data", "body"))
+				res = append(res, errors.Required("data", "body", ""))
 			} else {
 				res = append(res, errors.NewParseError("data", "body", "", err))
 			}
@@ -108,7 +108,7 @@ func (o *ReplaceGlobalParams) BindRequest(r *http.Request, route *middleware.Mat
 			}
 		}
 	} else {
-		res = append(res, errors.Required("data", "body"))
+		res = append(res, errors.Required("data", "body", ""))
 	}
 	qForceReload, qhkForceReload, _ := qs.GetOK("force_reload")
 	if err := o.bindForceReload(qForceReload, qhkForceReload, route.Formats); err != nil {

--- a/operations/http_request_rule/create_http_request_rule_parameters.go
+++ b/operations/http_request_rule/create_http_request_rule_parameters.go
@@ -104,7 +104,7 @@ func (o *CreateHTTPRequestRuleParams) BindRequest(r *http.Request, route *middle
 		var body models.HTTPRequestRule
 		if err := route.Consumer.Consume(r.Body, &body); err != nil {
 			if err == io.EOF {
-				res = append(res, errors.Required("data", "body"))
+				res = append(res, errors.Required("data", "body", ""))
 			} else {
 				res = append(res, errors.NewParseError("data", "body", "", err))
 			}
@@ -119,7 +119,7 @@ func (o *CreateHTTPRequestRuleParams) BindRequest(r *http.Request, route *middle
 			}
 		}
 	} else {
-		res = append(res, errors.Required("data", "body"))
+		res = append(res, errors.Required("data", "body", ""))
 	}
 	qForceReload, qhkForceReload, _ := qs.GetOK("force_reload")
 	if err := o.bindForceReload(qForceReload, qhkForceReload, route.Formats); err != nil {
@@ -178,7 +178,7 @@ func (o *CreateHTTPRequestRuleParams) bindForceReload(rawData []string, hasKey b
 // bindParentName binds and validates parameter ParentName from query.
 func (o *CreateHTTPRequestRuleParams) bindParentName(rawData []string, hasKey bool, formats strfmt.Registry) error {
 	if !hasKey {
-		return errors.Required("parent_name", "query")
+		return errors.Required("parent_name", "query", "")
 	}
 	var raw string
 	if len(rawData) > 0 {
@@ -199,7 +199,7 @@ func (o *CreateHTTPRequestRuleParams) bindParentName(rawData []string, hasKey bo
 // bindParentType binds and validates parameter ParentType from query.
 func (o *CreateHTTPRequestRuleParams) bindParentType(rawData []string, hasKey bool, formats strfmt.Registry) error {
 	if !hasKey {
-		return errors.Required("parent_type", "query")
+		return errors.Required("parent_type", "query", "")
 	}
 	var raw string
 	if len(rawData) > 0 {

--- a/operations/http_request_rule/delete_http_request_rule_parameters.go
+++ b/operations/http_request_rule/delete_http_request_rule_parameters.go
@@ -177,7 +177,7 @@ func (o *DeleteHTTPRequestRuleParams) bindIndex(rawData []string, hasKey bool, f
 // bindParentName binds and validates parameter ParentName from query.
 func (o *DeleteHTTPRequestRuleParams) bindParentName(rawData []string, hasKey bool, formats strfmt.Registry) error {
 	if !hasKey {
-		return errors.Required("parent_name", "query")
+		return errors.Required("parent_name", "query", "")
 	}
 	var raw string
 	if len(rawData) > 0 {
@@ -198,7 +198,7 @@ func (o *DeleteHTTPRequestRuleParams) bindParentName(rawData []string, hasKey bo
 // bindParentType binds and validates parameter ParentType from query.
 func (o *DeleteHTTPRequestRuleParams) bindParentType(rawData []string, hasKey bool, formats strfmt.Registry) error {
 	if !hasKey {
-		return errors.Required("parent_type", "query")
+		return errors.Required("parent_type", "query", "")
 	}
 	var raw string
 	if len(rawData) > 0 {

--- a/operations/http_request_rule/get_http_request_rule_parameters.go
+++ b/operations/http_request_rule/get_http_request_rule_parameters.go
@@ -127,7 +127,7 @@ func (o *GetHTTPRequestRuleParams) bindIndex(rawData []string, hasKey bool, form
 // bindParentName binds and validates parameter ParentName from query.
 func (o *GetHTTPRequestRuleParams) bindParentName(rawData []string, hasKey bool, formats strfmt.Registry) error {
 	if !hasKey {
-		return errors.Required("parent_name", "query")
+		return errors.Required("parent_name", "query", "")
 	}
 	var raw string
 	if len(rawData) > 0 {
@@ -148,7 +148,7 @@ func (o *GetHTTPRequestRuleParams) bindParentName(rawData []string, hasKey bool,
 // bindParentType binds and validates parameter ParentType from query.
 func (o *GetHTTPRequestRuleParams) bindParentType(rawData []string, hasKey bool, formats strfmt.Registry) error {
 	if !hasKey {
-		return errors.Required("parent_type", "query")
+		return errors.Required("parent_type", "query", "")
 	}
 	var raw string
 	if len(rawData) > 0 {

--- a/operations/http_request_rule/get_http_request_rules_parameters.go
+++ b/operations/http_request_rule/get_http_request_rules_parameters.go
@@ -97,7 +97,7 @@ func (o *GetHTTPRequestRulesParams) BindRequest(r *http.Request, route *middlewa
 // bindParentName binds and validates parameter ParentName from query.
 func (o *GetHTTPRequestRulesParams) bindParentName(rawData []string, hasKey bool, formats strfmt.Registry) error {
 	if !hasKey {
-		return errors.Required("parent_name", "query")
+		return errors.Required("parent_name", "query", "")
 	}
 	var raw string
 	if len(rawData) > 0 {
@@ -118,7 +118,7 @@ func (o *GetHTTPRequestRulesParams) bindParentName(rawData []string, hasKey bool
 // bindParentType binds and validates parameter ParentType from query.
 func (o *GetHTTPRequestRulesParams) bindParentType(rawData []string, hasKey bool, formats strfmt.Registry) error {
 	if !hasKey {
-		return errors.Required("parent_type", "query")
+		return errors.Required("parent_type", "query", "")
 	}
 	var raw string
 	if len(rawData) > 0 {

--- a/operations/http_request_rule/replace_http_request_rule_parameters.go
+++ b/operations/http_request_rule/replace_http_request_rule_parameters.go
@@ -109,7 +109,7 @@ func (o *ReplaceHTTPRequestRuleParams) BindRequest(r *http.Request, route *middl
 		var body models.HTTPRequestRule
 		if err := route.Consumer.Consume(r.Body, &body); err != nil {
 			if err == io.EOF {
-				res = append(res, errors.Required("data", "body"))
+				res = append(res, errors.Required("data", "body", ""))
 			} else {
 				res = append(res, errors.NewParseError("data", "body", "", err))
 			}
@@ -124,7 +124,7 @@ func (o *ReplaceHTTPRequestRuleParams) BindRequest(r *http.Request, route *middl
 			}
 		}
 	} else {
-		res = append(res, errors.Required("data", "body"))
+		res = append(res, errors.Required("data", "body", ""))
 	}
 	qForceReload, qhkForceReload, _ := qs.GetOK("force_reload")
 	if err := o.bindForceReload(qForceReload, qhkForceReload, route.Formats); err != nil {
@@ -207,7 +207,7 @@ func (o *ReplaceHTTPRequestRuleParams) bindIndex(rawData []string, hasKey bool, 
 // bindParentName binds and validates parameter ParentName from query.
 func (o *ReplaceHTTPRequestRuleParams) bindParentName(rawData []string, hasKey bool, formats strfmt.Registry) error {
 	if !hasKey {
-		return errors.Required("parent_name", "query")
+		return errors.Required("parent_name", "query", "")
 	}
 	var raw string
 	if len(rawData) > 0 {
@@ -228,7 +228,7 @@ func (o *ReplaceHTTPRequestRuleParams) bindParentName(rawData []string, hasKey b
 // bindParentType binds and validates parameter ParentType from query.
 func (o *ReplaceHTTPRequestRuleParams) bindParentType(rawData []string, hasKey bool, formats strfmt.Registry) error {
 	if !hasKey {
-		return errors.Required("parent_type", "query")
+		return errors.Required("parent_type", "query", "")
 	}
 	var raw string
 	if len(rawData) > 0 {

--- a/operations/http_response_rule/create_http_response_rule_parameters.go
+++ b/operations/http_response_rule/create_http_response_rule_parameters.go
@@ -104,7 +104,7 @@ func (o *CreateHTTPResponseRuleParams) BindRequest(r *http.Request, route *middl
 		var body models.HTTPResponseRule
 		if err := route.Consumer.Consume(r.Body, &body); err != nil {
 			if err == io.EOF {
-				res = append(res, errors.Required("data", "body"))
+				res = append(res, errors.Required("data", "body", ""))
 			} else {
 				res = append(res, errors.NewParseError("data", "body", "", err))
 			}
@@ -119,7 +119,7 @@ func (o *CreateHTTPResponseRuleParams) BindRequest(r *http.Request, route *middl
 			}
 		}
 	} else {
-		res = append(res, errors.Required("data", "body"))
+		res = append(res, errors.Required("data", "body", ""))
 	}
 	qForceReload, qhkForceReload, _ := qs.GetOK("force_reload")
 	if err := o.bindForceReload(qForceReload, qhkForceReload, route.Formats); err != nil {
@@ -178,7 +178,7 @@ func (o *CreateHTTPResponseRuleParams) bindForceReload(rawData []string, hasKey 
 // bindParentName binds and validates parameter ParentName from query.
 func (o *CreateHTTPResponseRuleParams) bindParentName(rawData []string, hasKey bool, formats strfmt.Registry) error {
 	if !hasKey {
-		return errors.Required("parent_name", "query")
+		return errors.Required("parent_name", "query", "")
 	}
 	var raw string
 	if len(rawData) > 0 {
@@ -199,7 +199,7 @@ func (o *CreateHTTPResponseRuleParams) bindParentName(rawData []string, hasKey b
 // bindParentType binds and validates parameter ParentType from query.
 func (o *CreateHTTPResponseRuleParams) bindParentType(rawData []string, hasKey bool, formats strfmt.Registry) error {
 	if !hasKey {
-		return errors.Required("parent_type", "query")
+		return errors.Required("parent_type", "query", "")
 	}
 	var raw string
 	if len(rawData) > 0 {

--- a/operations/http_response_rule/delete_http_response_rule_parameters.go
+++ b/operations/http_response_rule/delete_http_response_rule_parameters.go
@@ -177,7 +177,7 @@ func (o *DeleteHTTPResponseRuleParams) bindIndex(rawData []string, hasKey bool, 
 // bindParentName binds and validates parameter ParentName from query.
 func (o *DeleteHTTPResponseRuleParams) bindParentName(rawData []string, hasKey bool, formats strfmt.Registry) error {
 	if !hasKey {
-		return errors.Required("parent_name", "query")
+		return errors.Required("parent_name", "query", "")
 	}
 	var raw string
 	if len(rawData) > 0 {
@@ -198,7 +198,7 @@ func (o *DeleteHTTPResponseRuleParams) bindParentName(rawData []string, hasKey b
 // bindParentType binds and validates parameter ParentType from query.
 func (o *DeleteHTTPResponseRuleParams) bindParentType(rawData []string, hasKey bool, formats strfmt.Registry) error {
 	if !hasKey {
-		return errors.Required("parent_type", "query")
+		return errors.Required("parent_type", "query", "")
 	}
 	var raw string
 	if len(rawData) > 0 {

--- a/operations/http_response_rule/get_http_response_rule_parameters.go
+++ b/operations/http_response_rule/get_http_response_rule_parameters.go
@@ -127,7 +127,7 @@ func (o *GetHTTPResponseRuleParams) bindIndex(rawData []string, hasKey bool, for
 // bindParentName binds and validates parameter ParentName from query.
 func (o *GetHTTPResponseRuleParams) bindParentName(rawData []string, hasKey bool, formats strfmt.Registry) error {
 	if !hasKey {
-		return errors.Required("parent_name", "query")
+		return errors.Required("parent_name", "query", "")
 	}
 	var raw string
 	if len(rawData) > 0 {
@@ -148,7 +148,7 @@ func (o *GetHTTPResponseRuleParams) bindParentName(rawData []string, hasKey bool
 // bindParentType binds and validates parameter ParentType from query.
 func (o *GetHTTPResponseRuleParams) bindParentType(rawData []string, hasKey bool, formats strfmt.Registry) error {
 	if !hasKey {
-		return errors.Required("parent_type", "query")
+		return errors.Required("parent_type", "query", "")
 	}
 	var raw string
 	if len(rawData) > 0 {

--- a/operations/http_response_rule/get_http_response_rules_parameters.go
+++ b/operations/http_response_rule/get_http_response_rules_parameters.go
@@ -97,7 +97,7 @@ func (o *GetHTTPResponseRulesParams) BindRequest(r *http.Request, route *middlew
 // bindParentName binds and validates parameter ParentName from query.
 func (o *GetHTTPResponseRulesParams) bindParentName(rawData []string, hasKey bool, formats strfmt.Registry) error {
 	if !hasKey {
-		return errors.Required("parent_name", "query")
+		return errors.Required("parent_name", "query", "")
 	}
 	var raw string
 	if len(rawData) > 0 {
@@ -118,7 +118,7 @@ func (o *GetHTTPResponseRulesParams) bindParentName(rawData []string, hasKey boo
 // bindParentType binds and validates parameter ParentType from query.
 func (o *GetHTTPResponseRulesParams) bindParentType(rawData []string, hasKey bool, formats strfmt.Registry) error {
 	if !hasKey {
-		return errors.Required("parent_type", "query")
+		return errors.Required("parent_type", "query", "")
 	}
 	var raw string
 	if len(rawData) > 0 {

--- a/operations/http_response_rule/replace_http_response_rule_parameters.go
+++ b/operations/http_response_rule/replace_http_response_rule_parameters.go
@@ -109,7 +109,7 @@ func (o *ReplaceHTTPResponseRuleParams) BindRequest(r *http.Request, route *midd
 		var body models.HTTPResponseRule
 		if err := route.Consumer.Consume(r.Body, &body); err != nil {
 			if err == io.EOF {
-				res = append(res, errors.Required("data", "body"))
+				res = append(res, errors.Required("data", "body", ""))
 			} else {
 				res = append(res, errors.NewParseError("data", "body", "", err))
 			}
@@ -124,7 +124,7 @@ func (o *ReplaceHTTPResponseRuleParams) BindRequest(r *http.Request, route *midd
 			}
 		}
 	} else {
-		res = append(res, errors.Required("data", "body"))
+		res = append(res, errors.Required("data", "body", ""))
 	}
 	qForceReload, qhkForceReload, _ := qs.GetOK("force_reload")
 	if err := o.bindForceReload(qForceReload, qhkForceReload, route.Formats); err != nil {
@@ -207,7 +207,7 @@ func (o *ReplaceHTTPResponseRuleParams) bindIndex(rawData []string, hasKey bool,
 // bindParentName binds and validates parameter ParentName from query.
 func (o *ReplaceHTTPResponseRuleParams) bindParentName(rawData []string, hasKey bool, formats strfmt.Registry) error {
 	if !hasKey {
-		return errors.Required("parent_name", "query")
+		return errors.Required("parent_name", "query", "")
 	}
 	var raw string
 	if len(rawData) > 0 {
@@ -228,7 +228,7 @@ func (o *ReplaceHTTPResponseRuleParams) bindParentName(rawData []string, hasKey 
 // bindParentType binds and validates parameter ParentType from query.
 func (o *ReplaceHTTPResponseRuleParams) bindParentType(rawData []string, hasKey bool, formats strfmt.Registry) error {
 	if !hasKey {
-		return errors.Required("parent_type", "query")
+		return errors.Required("parent_type", "query", "")
 	}
 	var raw string
 	if len(rawData) > 0 {

--- a/operations/log_target/create_log_target_parameters.go
+++ b/operations/log_target/create_log_target_parameters.go
@@ -104,7 +104,7 @@ func (o *CreateLogTargetParams) BindRequest(r *http.Request, route *middleware.M
 		var body models.LogTarget
 		if err := route.Consumer.Consume(r.Body, &body); err != nil {
 			if err == io.EOF {
-				res = append(res, errors.Required("data", "body"))
+				res = append(res, errors.Required("data", "body", ""))
 			} else {
 				res = append(res, errors.NewParseError("data", "body", "", err))
 			}
@@ -119,7 +119,7 @@ func (o *CreateLogTargetParams) BindRequest(r *http.Request, route *middleware.M
 			}
 		}
 	} else {
-		res = append(res, errors.Required("data", "body"))
+		res = append(res, errors.Required("data", "body", ""))
 	}
 	qForceReload, qhkForceReload, _ := qs.GetOK("force_reload")
 	if err := o.bindForceReload(qForceReload, qhkForceReload, route.Formats); err != nil {
@@ -178,7 +178,7 @@ func (o *CreateLogTargetParams) bindForceReload(rawData []string, hasKey bool, f
 // bindParentName binds and validates parameter ParentName from query.
 func (o *CreateLogTargetParams) bindParentName(rawData []string, hasKey bool, formats strfmt.Registry) error {
 	if !hasKey {
-		return errors.Required("parent_name", "query")
+		return errors.Required("parent_name", "query", "")
 	}
 	var raw string
 	if len(rawData) > 0 {
@@ -199,7 +199,7 @@ func (o *CreateLogTargetParams) bindParentName(rawData []string, hasKey bool, fo
 // bindParentType binds and validates parameter ParentType from query.
 func (o *CreateLogTargetParams) bindParentType(rawData []string, hasKey bool, formats strfmt.Registry) error {
 	if !hasKey {
-		return errors.Required("parent_type", "query")
+		return errors.Required("parent_type", "query", "")
 	}
 	var raw string
 	if len(rawData) > 0 {

--- a/operations/log_target/delete_log_target_parameters.go
+++ b/operations/log_target/delete_log_target_parameters.go
@@ -177,7 +177,7 @@ func (o *DeleteLogTargetParams) bindIndex(rawData []string, hasKey bool, formats
 // bindParentName binds and validates parameter ParentName from query.
 func (o *DeleteLogTargetParams) bindParentName(rawData []string, hasKey bool, formats strfmt.Registry) error {
 	if !hasKey {
-		return errors.Required("parent_name", "query")
+		return errors.Required("parent_name", "query", "")
 	}
 	var raw string
 	if len(rawData) > 0 {
@@ -198,7 +198,7 @@ func (o *DeleteLogTargetParams) bindParentName(rawData []string, hasKey bool, fo
 // bindParentType binds and validates parameter ParentType from query.
 func (o *DeleteLogTargetParams) bindParentType(rawData []string, hasKey bool, formats strfmt.Registry) error {
 	if !hasKey {
-		return errors.Required("parent_type", "query")
+		return errors.Required("parent_type", "query", "")
 	}
 	var raw string
 	if len(rawData) > 0 {

--- a/operations/log_target/get_log_target_parameters.go
+++ b/operations/log_target/get_log_target_parameters.go
@@ -127,7 +127,7 @@ func (o *GetLogTargetParams) bindIndex(rawData []string, hasKey bool, formats st
 // bindParentName binds and validates parameter ParentName from query.
 func (o *GetLogTargetParams) bindParentName(rawData []string, hasKey bool, formats strfmt.Registry) error {
 	if !hasKey {
-		return errors.Required("parent_name", "query")
+		return errors.Required("parent_name", "query", "")
 	}
 	var raw string
 	if len(rawData) > 0 {
@@ -148,7 +148,7 @@ func (o *GetLogTargetParams) bindParentName(rawData []string, hasKey bool, forma
 // bindParentType binds and validates parameter ParentType from query.
 func (o *GetLogTargetParams) bindParentType(rawData []string, hasKey bool, formats strfmt.Registry) error {
 	if !hasKey {
-		return errors.Required("parent_type", "query")
+		return errors.Required("parent_type", "query", "")
 	}
 	var raw string
 	if len(rawData) > 0 {

--- a/operations/log_target/get_log_targets_parameters.go
+++ b/operations/log_target/get_log_targets_parameters.go
@@ -97,7 +97,7 @@ func (o *GetLogTargetsParams) BindRequest(r *http.Request, route *middleware.Mat
 // bindParentName binds and validates parameter ParentName from query.
 func (o *GetLogTargetsParams) bindParentName(rawData []string, hasKey bool, formats strfmt.Registry) error {
 	if !hasKey {
-		return errors.Required("parent_name", "query")
+		return errors.Required("parent_name", "query", "")
 	}
 	var raw string
 	if len(rawData) > 0 {
@@ -118,7 +118,7 @@ func (o *GetLogTargetsParams) bindParentName(rawData []string, hasKey bool, form
 // bindParentType binds and validates parameter ParentType from query.
 func (o *GetLogTargetsParams) bindParentType(rawData []string, hasKey bool, formats strfmt.Registry) error {
 	if !hasKey {
-		return errors.Required("parent_type", "query")
+		return errors.Required("parent_type", "query", "")
 	}
 	var raw string
 	if len(rawData) > 0 {

--- a/operations/log_target/replace_log_target_parameters.go
+++ b/operations/log_target/replace_log_target_parameters.go
@@ -109,7 +109,7 @@ func (o *ReplaceLogTargetParams) BindRequest(r *http.Request, route *middleware.
 		var body models.LogTarget
 		if err := route.Consumer.Consume(r.Body, &body); err != nil {
 			if err == io.EOF {
-				res = append(res, errors.Required("data", "body"))
+				res = append(res, errors.Required("data", "body", ""))
 			} else {
 				res = append(res, errors.NewParseError("data", "body", "", err))
 			}
@@ -124,7 +124,7 @@ func (o *ReplaceLogTargetParams) BindRequest(r *http.Request, route *middleware.
 			}
 		}
 	} else {
-		res = append(res, errors.Required("data", "body"))
+		res = append(res, errors.Required("data", "body", ""))
 	}
 	qForceReload, qhkForceReload, _ := qs.GetOK("force_reload")
 	if err := o.bindForceReload(qForceReload, qhkForceReload, route.Formats); err != nil {
@@ -207,7 +207,7 @@ func (o *ReplaceLogTargetParams) bindIndex(rawData []string, hasKey bool, format
 // bindParentName binds and validates parameter ParentName from query.
 func (o *ReplaceLogTargetParams) bindParentName(rawData []string, hasKey bool, formats strfmt.Registry) error {
 	if !hasKey {
-		return errors.Required("parent_name", "query")
+		return errors.Required("parent_name", "query", "")
 	}
 	var raw string
 	if len(rawData) > 0 {
@@ -228,7 +228,7 @@ func (o *ReplaceLogTargetParams) bindParentName(rawData []string, hasKey bool, f
 // bindParentType binds and validates parameter ParentType from query.
 func (o *ReplaceLogTargetParams) bindParentType(rawData []string, hasKey bool, formats strfmt.Registry) error {
 	if !hasKey {
-		return errors.Required("parent_type", "query")
+		return errors.Required("parent_type", "query", "")
 	}
 	var raw string
 	if len(rawData) > 0 {

--- a/operations/maps/add_map_entry_parameters.go
+++ b/operations/maps/add_map_entry_parameters.go
@@ -77,7 +77,7 @@ func (o *AddMapEntryParams) BindRequest(r *http.Request, route *middleware.Match
 		var body models.MapEntry
 		if err := route.Consumer.Consume(r.Body, &body); err != nil {
 			if err == io.EOF {
-				res = append(res, errors.Required("data", "body"))
+				res = append(res, errors.Required("data", "body", ""))
 			} else {
 				res = append(res, errors.NewParseError("data", "body", "", err))
 			}
@@ -92,7 +92,7 @@ func (o *AddMapEntryParams) BindRequest(r *http.Request, route *middleware.Match
 			}
 		}
 	} else {
-		res = append(res, errors.Required("data", "body"))
+		res = append(res, errors.Required("data", "body", ""))
 	}
 	qMap, qhkMap, _ := qs.GetOK("map")
 	if err := o.bindMap(qMap, qhkMap, route.Formats); err != nil {
@@ -108,7 +108,7 @@ func (o *AddMapEntryParams) BindRequest(r *http.Request, route *middleware.Match
 // bindMap binds and validates parameter Map from query.
 func (o *AddMapEntryParams) bindMap(rawData []string, hasKey bool, formats strfmt.Registry) error {
 	if !hasKey {
-		return errors.Required("map", "query")
+		return errors.Required("map", "query", "")
 	}
 	var raw string
 	if len(rawData) > 0 {

--- a/operations/maps/delete_runtime_map_entry_parameters.go
+++ b/operations/maps/delete_runtime_map_entry_parameters.go
@@ -103,7 +103,7 @@ func (o *DeleteRuntimeMapEntryParams) bindID(rawData []string, hasKey bool, form
 // bindMap binds and validates parameter Map from query.
 func (o *DeleteRuntimeMapEntryParams) bindMap(rawData []string, hasKey bool, formats strfmt.Registry) error {
 	if !hasKey {
-		return errors.Required("map", "query")
+		return errors.Required("map", "query", "")
 	}
 	var raw string
 	if len(rawData) > 0 {

--- a/operations/maps/get_runtime_map_entry_parameters.go
+++ b/operations/maps/get_runtime_map_entry_parameters.go
@@ -103,7 +103,7 @@ func (o *GetRuntimeMapEntryParams) bindID(rawData []string, hasKey bool, formats
 // bindMap binds and validates parameter Map from query.
 func (o *GetRuntimeMapEntryParams) bindMap(rawData []string, hasKey bool, formats strfmt.Registry) error {
 	if !hasKey {
-		return errors.Required("map", "query")
+		return errors.Required("map", "query", "")
 	}
 	var raw string
 	if len(rawData) > 0 {

--- a/operations/maps/replace_runtime_map_entry_parameters.go
+++ b/operations/maps/replace_runtime_map_entry_parameters.go
@@ -80,7 +80,7 @@ func (o *ReplaceRuntimeMapEntryParams) BindRequest(r *http.Request, route *middl
 		var body ReplaceRuntimeMapEntryBody
 		if err := route.Consumer.Consume(r.Body, &body); err != nil {
 			if err == io.EOF {
-				res = append(res, errors.Required("data", "body"))
+				res = append(res, errors.Required("data", "body", ""))
 			} else {
 				res = append(res, errors.NewParseError("data", "body", "", err))
 			}
@@ -95,7 +95,7 @@ func (o *ReplaceRuntimeMapEntryParams) BindRequest(r *http.Request, route *middl
 			}
 		}
 	} else {
-		res = append(res, errors.Required("data", "body"))
+		res = append(res, errors.Required("data", "body", ""))
 	}
 	rID, rhkID, _ := route.Params.GetOK("id")
 	if err := o.bindID(rID, rhkID, route.Formats); err != nil {
@@ -131,7 +131,7 @@ func (o *ReplaceRuntimeMapEntryParams) bindID(rawData []string, hasKey bool, for
 // bindMap binds and validates parameter Map from query.
 func (o *ReplaceRuntimeMapEntryParams) bindMap(rawData []string, hasKey bool, formats strfmt.Registry) error {
 	if !hasKey {
-		return errors.Required("map", "query")
+		return errors.Required("map", "query", "")
 	}
 	var raw string
 	if len(rawData) > 0 {

--- a/operations/maps/show_runtime_map_parameters.go
+++ b/operations/maps/show_runtime_map_parameters.go
@@ -78,7 +78,7 @@ func (o *ShowRuntimeMapParams) BindRequest(r *http.Request, route *middleware.Ma
 // bindMap binds and validates parameter Map from query.
 func (o *ShowRuntimeMapParams) bindMap(rawData []string, hasKey bool, formats strfmt.Registry) error {
 	if !hasKey {
-		return errors.Required("map", "query")
+		return errors.Required("map", "query", "")
 	}
 	var raw string
 	if len(rawData) > 0 {

--- a/operations/nameserver/create_nameserver_parameters.go
+++ b/operations/nameserver/create_nameserver_parameters.go
@@ -99,7 +99,7 @@ func (o *CreateNameserverParams) BindRequest(r *http.Request, route *middleware.
 		var body models.Nameserver
 		if err := route.Consumer.Consume(r.Body, &body); err != nil {
 			if err == io.EOF {
-				res = append(res, errors.Required("data", "body"))
+				res = append(res, errors.Required("data", "body", ""))
 			} else {
 				res = append(res, errors.NewParseError("data", "body", "", err))
 			}
@@ -114,7 +114,7 @@ func (o *CreateNameserverParams) BindRequest(r *http.Request, route *middleware.
 			}
 		}
 	} else {
-		res = append(res, errors.Required("data", "body"))
+		res = append(res, errors.Required("data", "body", ""))
 	}
 	qForceReload, qhkForceReload, _ := qs.GetOK("force_reload")
 	if err := o.bindForceReload(qForceReload, qhkForceReload, route.Formats); err != nil {
@@ -168,7 +168,7 @@ func (o *CreateNameserverParams) bindForceReload(rawData []string, hasKey bool, 
 // bindResolver binds and validates parameter Resolver from query.
 func (o *CreateNameserverParams) bindResolver(rawData []string, hasKey bool, formats strfmt.Registry) error {
 	if !hasKey {
-		return errors.Required("resolver", "query")
+		return errors.Required("resolver", "query", "")
 	}
 	var raw string
 	if len(rawData) > 0 {

--- a/operations/nameserver/delete_nameserver_parameters.go
+++ b/operations/nameserver/delete_nameserver_parameters.go
@@ -163,7 +163,7 @@ func (o *DeleteNameserverParams) bindName(rawData []string, hasKey bool, formats
 // bindResolver binds and validates parameter Resolver from query.
 func (o *DeleteNameserverParams) bindResolver(rawData []string, hasKey bool, formats strfmt.Registry) error {
 	if !hasKey {
-		return errors.Required("resolver", "query")
+		return errors.Required("resolver", "query", "")
 	}
 	var raw string
 	if len(rawData) > 0 {

--- a/operations/nameserver/get_nameserver_parameters.go
+++ b/operations/nameserver/get_nameserver_parameters.go
@@ -112,7 +112,7 @@ func (o *GetNameserverParams) bindName(rawData []string, hasKey bool, formats st
 // bindResolver binds and validates parameter Resolver from query.
 func (o *GetNameserverParams) bindResolver(rawData []string, hasKey bool, formats strfmt.Registry) error {
 	if !hasKey {
-		return errors.Required("resolver", "query")
+		return errors.Required("resolver", "query", "")
 	}
 	var raw string
 	if len(rawData) > 0 {

--- a/operations/nameserver/get_nameservers_parameters.go
+++ b/operations/nameserver/get_nameservers_parameters.go
@@ -87,7 +87,7 @@ func (o *GetNameserversParams) BindRequest(r *http.Request, route *middleware.Ma
 // bindResolver binds and validates parameter Resolver from query.
 func (o *GetNameserversParams) bindResolver(rawData []string, hasKey bool, formats strfmt.Registry) error {
 	if !hasKey {
-		return errors.Required("resolver", "query")
+		return errors.Required("resolver", "query", "")
 	}
 	var raw string
 	if len(rawData) > 0 {

--- a/operations/nameserver/replace_nameserver_parameters.go
+++ b/operations/nameserver/replace_nameserver_parameters.go
@@ -104,7 +104,7 @@ func (o *ReplaceNameserverParams) BindRequest(r *http.Request, route *middleware
 		var body models.Nameserver
 		if err := route.Consumer.Consume(r.Body, &body); err != nil {
 			if err == io.EOF {
-				res = append(res, errors.Required("data", "body"))
+				res = append(res, errors.Required("data", "body", ""))
 			} else {
 				res = append(res, errors.NewParseError("data", "body", "", err))
 			}
@@ -119,7 +119,7 @@ func (o *ReplaceNameserverParams) BindRequest(r *http.Request, route *middleware
 			}
 		}
 	} else {
-		res = append(res, errors.Required("data", "body"))
+		res = append(res, errors.Required("data", "body", ""))
 	}
 	qForceReload, qhkForceReload, _ := qs.GetOK("force_reload")
 	if err := o.bindForceReload(qForceReload, qhkForceReload, route.Formats); err != nil {
@@ -193,7 +193,7 @@ func (o *ReplaceNameserverParams) bindName(rawData []string, hasKey bool, format
 // bindResolver binds and validates parameter Resolver from query.
 func (o *ReplaceNameserverParams) bindResolver(rawData []string, hasKey bool, formats strfmt.Registry) error {
 	if !hasKey {
-		return errors.Required("resolver", "query")
+		return errors.Required("resolver", "query", "")
 	}
 	var raw string
 	if len(rawData) > 0 {

--- a/operations/peer/create_peer_parameters.go
+++ b/operations/peer/create_peer_parameters.go
@@ -93,7 +93,7 @@ func (o *CreatePeerParams) BindRequest(r *http.Request, route *middleware.Matche
 		var body models.PeerSection
 		if err := route.Consumer.Consume(r.Body, &body); err != nil {
 			if err == io.EOF {
-				res = append(res, errors.Required("data", "body"))
+				res = append(res, errors.Required("data", "body", ""))
 			} else {
 				res = append(res, errors.NewParseError("data", "body", "", err))
 			}
@@ -108,7 +108,7 @@ func (o *CreatePeerParams) BindRequest(r *http.Request, route *middleware.Matche
 			}
 		}
 	} else {
-		res = append(res, errors.Required("data", "body"))
+		res = append(res, errors.Required("data", "body", ""))
 	}
 	qForceReload, qhkForceReload, _ := qs.GetOK("force_reload")
 	if err := o.bindForceReload(qForceReload, qhkForceReload, route.Formats); err != nil {

--- a/operations/peer_entry/create_peer_entry_parameters.go
+++ b/operations/peer_entry/create_peer_entry_parameters.go
@@ -99,7 +99,7 @@ func (o *CreatePeerEntryParams) BindRequest(r *http.Request, route *middleware.M
 		var body models.PeerEntry
 		if err := route.Consumer.Consume(r.Body, &body); err != nil {
 			if err == io.EOF {
-				res = append(res, errors.Required("data", "body"))
+				res = append(res, errors.Required("data", "body", ""))
 			} else {
 				res = append(res, errors.NewParseError("data", "body", "", err))
 			}
@@ -114,7 +114,7 @@ func (o *CreatePeerEntryParams) BindRequest(r *http.Request, route *middleware.M
 			}
 		}
 	} else {
-		res = append(res, errors.Required("data", "body"))
+		res = append(res, errors.Required("data", "body", ""))
 	}
 	qForceReload, qhkForceReload, _ := qs.GetOK("force_reload")
 	if err := o.bindForceReload(qForceReload, qhkForceReload, route.Formats); err != nil {
@@ -168,7 +168,7 @@ func (o *CreatePeerEntryParams) bindForceReload(rawData []string, hasKey bool, f
 // bindPeerSection binds and validates parameter PeerSection from query.
 func (o *CreatePeerEntryParams) bindPeerSection(rawData []string, hasKey bool, formats strfmt.Registry) error {
 	if !hasKey {
-		return errors.Required("peer_section", "query")
+		return errors.Required("peer_section", "query", "")
 	}
 	var raw string
 	if len(rawData) > 0 {

--- a/operations/peer_entry/delete_peer_entry_parameters.go
+++ b/operations/peer_entry/delete_peer_entry_parameters.go
@@ -163,7 +163,7 @@ func (o *DeletePeerEntryParams) bindName(rawData []string, hasKey bool, formats 
 // bindPeerSection binds and validates parameter PeerSection from query.
 func (o *DeletePeerEntryParams) bindPeerSection(rawData []string, hasKey bool, formats strfmt.Registry) error {
 	if !hasKey {
-		return errors.Required("peer_section", "query")
+		return errors.Required("peer_section", "query", "")
 	}
 	var raw string
 	if len(rawData) > 0 {

--- a/operations/peer_entry/get_peer_entries_parameters.go
+++ b/operations/peer_entry/get_peer_entries_parameters.go
@@ -87,7 +87,7 @@ func (o *GetPeerEntriesParams) BindRequest(r *http.Request, route *middleware.Ma
 // bindPeerSection binds and validates parameter PeerSection from query.
 func (o *GetPeerEntriesParams) bindPeerSection(rawData []string, hasKey bool, formats strfmt.Registry) error {
 	if !hasKey {
-		return errors.Required("peer_section", "query")
+		return errors.Required("peer_section", "query", "")
 	}
 	var raw string
 	if len(rawData) > 0 {

--- a/operations/peer_entry/get_peer_entry_parameters.go
+++ b/operations/peer_entry/get_peer_entry_parameters.go
@@ -112,7 +112,7 @@ func (o *GetPeerEntryParams) bindName(rawData []string, hasKey bool, formats str
 // bindPeerSection binds and validates parameter PeerSection from query.
 func (o *GetPeerEntryParams) bindPeerSection(rawData []string, hasKey bool, formats strfmt.Registry) error {
 	if !hasKey {
-		return errors.Required("peer_section", "query")
+		return errors.Required("peer_section", "query", "")
 	}
 	var raw string
 	if len(rawData) > 0 {

--- a/operations/peer_entry/replace_peer_entry_parameters.go
+++ b/operations/peer_entry/replace_peer_entry_parameters.go
@@ -104,7 +104,7 @@ func (o *ReplacePeerEntryParams) BindRequest(r *http.Request, route *middleware.
 		var body models.PeerEntry
 		if err := route.Consumer.Consume(r.Body, &body); err != nil {
 			if err == io.EOF {
-				res = append(res, errors.Required("data", "body"))
+				res = append(res, errors.Required("data", "body", ""))
 			} else {
 				res = append(res, errors.NewParseError("data", "body", "", err))
 			}
@@ -119,7 +119,7 @@ func (o *ReplacePeerEntryParams) BindRequest(r *http.Request, route *middleware.
 			}
 		}
 	} else {
-		res = append(res, errors.Required("data", "body"))
+		res = append(res, errors.Required("data", "body", ""))
 	}
 	qForceReload, qhkForceReload, _ := qs.GetOK("force_reload")
 	if err := o.bindForceReload(qForceReload, qhkForceReload, route.Formats); err != nil {
@@ -193,7 +193,7 @@ func (o *ReplacePeerEntryParams) bindName(rawData []string, hasKey bool, formats
 // bindPeerSection binds and validates parameter PeerSection from query.
 func (o *ReplacePeerEntryParams) bindPeerSection(rawData []string, hasKey bool, formats strfmt.Registry) error {
 	if !hasKey {
-		return errors.Required("peer_section", "query")
+		return errors.Required("peer_section", "query", "")
 	}
 	var raw string
 	if len(rawData) > 0 {

--- a/operations/resolver/create_resolver_parameters.go
+++ b/operations/resolver/create_resolver_parameters.go
@@ -93,7 +93,7 @@ func (o *CreateResolverParams) BindRequest(r *http.Request, route *middleware.Ma
 		var body models.Resolver
 		if err := route.Consumer.Consume(r.Body, &body); err != nil {
 			if err == io.EOF {
-				res = append(res, errors.Required("data", "body"))
+				res = append(res, errors.Required("data", "body", ""))
 			} else {
 				res = append(res, errors.NewParseError("data", "body", "", err))
 			}
@@ -108,7 +108,7 @@ func (o *CreateResolverParams) BindRequest(r *http.Request, route *middleware.Ma
 			}
 		}
 	} else {
-		res = append(res, errors.Required("data", "body"))
+		res = append(res, errors.Required("data", "body", ""))
 	}
 	qForceReload, qhkForceReload, _ := qs.GetOK("force_reload")
 	if err := o.bindForceReload(qForceReload, qhkForceReload, route.Formats); err != nil {

--- a/operations/resolver/replace_resolver_parameters.go
+++ b/operations/resolver/replace_resolver_parameters.go
@@ -98,7 +98,7 @@ func (o *ReplaceResolverParams) BindRequest(r *http.Request, route *middleware.M
 		var body models.Resolver
 		if err := route.Consumer.Consume(r.Body, &body); err != nil {
 			if err == io.EOF {
-				res = append(res, errors.Required("data", "body"))
+				res = append(res, errors.Required("data", "body", ""))
 			} else {
 				res = append(res, errors.NewParseError("data", "body", "", err))
 			}
@@ -113,7 +113,7 @@ func (o *ReplaceResolverParams) BindRequest(r *http.Request, route *middleware.M
 			}
 		}
 	} else {
-		res = append(res, errors.Required("data", "body"))
+		res = append(res, errors.Required("data", "body", ""))
 	}
 	qForceReload, qhkForceReload, _ := qs.GetOK("force_reload")
 	if err := o.bindForceReload(qForceReload, qhkForceReload, route.Formats); err != nil {

--- a/operations/server/create_server_parameters.go
+++ b/operations/server/create_server_parameters.go
@@ -104,7 +104,7 @@ func (o *CreateServerParams) BindRequest(r *http.Request, route *middleware.Matc
 		var body models.Server
 		if err := route.Consumer.Consume(r.Body, &body); err != nil {
 			if err == io.EOF {
-				res = append(res, errors.Required("data", "body"))
+				res = append(res, errors.Required("data", "body", ""))
 			} else {
 				res = append(res, errors.NewParseError("data", "body", "", err))
 			}
@@ -119,7 +119,7 @@ func (o *CreateServerParams) BindRequest(r *http.Request, route *middleware.Matc
 			}
 		}
 	} else {
-		res = append(res, errors.Required("data", "body"))
+		res = append(res, errors.Required("data", "body", ""))
 	}
 	qForceReload, qhkForceReload, _ := qs.GetOK("force_reload")
 	if err := o.bindForceReload(qForceReload, qhkForceReload, route.Formats); err != nil {
@@ -145,7 +145,7 @@ func (o *CreateServerParams) BindRequest(r *http.Request, route *middleware.Matc
 // bindBackend binds and validates parameter Backend from query.
 func (o *CreateServerParams) bindBackend(rawData []string, hasKey bool, formats strfmt.Registry) error {
 	if !hasKey {
-		return errors.Required("backend", "query")
+		return errors.Required("backend", "query", "")
 	}
 	var raw string
 	if len(rawData) > 0 {

--- a/operations/server/delete_server_parameters.go
+++ b/operations/server/delete_server_parameters.go
@@ -125,7 +125,7 @@ func (o *DeleteServerParams) BindRequest(r *http.Request, route *middleware.Matc
 // bindBackend binds and validates parameter Backend from query.
 func (o *DeleteServerParams) bindBackend(rawData []string, hasKey bool, formats strfmt.Registry) error {
 	if !hasKey {
-		return errors.Required("backend", "query")
+		return errors.Required("backend", "query", "")
 	}
 	var raw string
 	if len(rawData) > 0 {

--- a/operations/server/get_runtime_server_parameters.go
+++ b/operations/server/get_runtime_server_parameters.go
@@ -88,7 +88,7 @@ func (o *GetRuntimeServerParams) BindRequest(r *http.Request, route *middleware.
 // bindBackend binds and validates parameter Backend from query.
 func (o *GetRuntimeServerParams) bindBackend(rawData []string, hasKey bool, formats strfmt.Registry) error {
 	if !hasKey {
-		return errors.Required("backend", "query")
+		return errors.Required("backend", "query", "")
 	}
 	var raw string
 	if len(rawData) > 0 {

--- a/operations/server/get_runtime_servers_parameters.go
+++ b/operations/server/get_runtime_servers_parameters.go
@@ -78,7 +78,7 @@ func (o *GetRuntimeServersParams) BindRequest(r *http.Request, route *middleware
 // bindBackend binds and validates parameter Backend from query.
 func (o *GetRuntimeServersParams) bindBackend(rawData []string, hasKey bool, formats strfmt.Registry) error {
 	if !hasKey {
-		return errors.Required("backend", "query")
+		return errors.Required("backend", "query", "")
 	}
 	var raw string
 	if len(rawData) > 0 {

--- a/operations/server/get_server_parameters.go
+++ b/operations/server/get_server_parameters.go
@@ -97,7 +97,7 @@ func (o *GetServerParams) BindRequest(r *http.Request, route *middleware.Matched
 // bindBackend binds and validates parameter Backend from query.
 func (o *GetServerParams) bindBackend(rawData []string, hasKey bool, formats strfmt.Registry) error {
 	if !hasKey {
-		return errors.Required("backend", "query")
+		return errors.Required("backend", "query", "")
 	}
 	var raw string
 	if len(rawData) > 0 {

--- a/operations/server/get_servers_parameters.go
+++ b/operations/server/get_servers_parameters.go
@@ -87,7 +87,7 @@ func (o *GetServersParams) BindRequest(r *http.Request, route *middleware.Matche
 // bindBackend binds and validates parameter Backend from query.
 func (o *GetServersParams) bindBackend(rawData []string, hasKey bool, formats strfmt.Registry) error {
 	if !hasKey {
-		return errors.Required("backend", "query")
+		return errors.Required("backend", "query", "")
 	}
 	var raw string
 	if len(rawData) > 0 {

--- a/operations/server/replace_runtime_server_parameters.go
+++ b/operations/server/replace_runtime_server_parameters.go
@@ -87,7 +87,7 @@ func (o *ReplaceRuntimeServerParams) BindRequest(r *http.Request, route *middlew
 		var body models.RuntimeServer
 		if err := route.Consumer.Consume(r.Body, &body); err != nil {
 			if err == io.EOF {
-				res = append(res, errors.Required("data", "body"))
+				res = append(res, errors.Required("data", "body", ""))
 			} else {
 				res = append(res, errors.NewParseError("data", "body", "", err))
 			}
@@ -102,7 +102,7 @@ func (o *ReplaceRuntimeServerParams) BindRequest(r *http.Request, route *middlew
 			}
 		}
 	} else {
-		res = append(res, errors.Required("data", "body"))
+		res = append(res, errors.Required("data", "body", ""))
 	}
 	rName, rhkName, _ := route.Params.GetOK("name")
 	if err := o.bindName(rName, rhkName, route.Formats); err != nil {
@@ -118,7 +118,7 @@ func (o *ReplaceRuntimeServerParams) BindRequest(r *http.Request, route *middlew
 // bindBackend binds and validates parameter Backend from query.
 func (o *ReplaceRuntimeServerParams) bindBackend(rawData []string, hasKey bool, formats strfmt.Registry) error {
 	if !hasKey {
-		return errors.Required("backend", "query")
+		return errors.Required("backend", "query", "")
 	}
 	var raw string
 	if len(rawData) > 0 {

--- a/operations/server/replace_server_parameters.go
+++ b/operations/server/replace_server_parameters.go
@@ -109,7 +109,7 @@ func (o *ReplaceServerParams) BindRequest(r *http.Request, route *middleware.Mat
 		var body models.Server
 		if err := route.Consumer.Consume(r.Body, &body); err != nil {
 			if err == io.EOF {
-				res = append(res, errors.Required("data", "body"))
+				res = append(res, errors.Required("data", "body", ""))
 			} else {
 				res = append(res, errors.NewParseError("data", "body", "", err))
 			}
@@ -124,7 +124,7 @@ func (o *ReplaceServerParams) BindRequest(r *http.Request, route *middleware.Mat
 			}
 		}
 	} else {
-		res = append(res, errors.Required("data", "body"))
+		res = append(res, errors.Required("data", "body", ""))
 	}
 	qForceReload, qhkForceReload, _ := qs.GetOK("force_reload")
 	if err := o.bindForceReload(qForceReload, qhkForceReload, route.Formats); err != nil {
@@ -155,7 +155,7 @@ func (o *ReplaceServerParams) BindRequest(r *http.Request, route *middleware.Mat
 // bindBackend binds and validates parameter Backend from query.
 func (o *ReplaceServerParams) bindBackend(rawData []string, hasKey bool, formats strfmt.Registry) error {
 	if !hasKey {
-		return errors.Required("backend", "query")
+		return errors.Required("backend", "query", "")
 	}
 	var raw string
 	if len(rawData) > 0 {

--- a/operations/server_switching_rule/create_server_switching_rule_parameters.go
+++ b/operations/server_switching_rule/create_server_switching_rule_parameters.go
@@ -104,7 +104,7 @@ func (o *CreateServerSwitchingRuleParams) BindRequest(r *http.Request, route *mi
 		var body models.ServerSwitchingRule
 		if err := route.Consumer.Consume(r.Body, &body); err != nil {
 			if err == io.EOF {
-				res = append(res, errors.Required("data", "body"))
+				res = append(res, errors.Required("data", "body", ""))
 			} else {
 				res = append(res, errors.NewParseError("data", "body", "", err))
 			}
@@ -119,7 +119,7 @@ func (o *CreateServerSwitchingRuleParams) BindRequest(r *http.Request, route *mi
 			}
 		}
 	} else {
-		res = append(res, errors.Required("data", "body"))
+		res = append(res, errors.Required("data", "body", ""))
 	}
 	qForceReload, qhkForceReload, _ := qs.GetOK("force_reload")
 	if err := o.bindForceReload(qForceReload, qhkForceReload, route.Formats); err != nil {
@@ -145,7 +145,7 @@ func (o *CreateServerSwitchingRuleParams) BindRequest(r *http.Request, route *mi
 // bindBackend binds and validates parameter Backend from query.
 func (o *CreateServerSwitchingRuleParams) bindBackend(rawData []string, hasKey bool, formats strfmt.Registry) error {
 	if !hasKey {
-		return errors.Required("backend", "query")
+		return errors.Required("backend", "query", "")
 	}
 	var raw string
 	if len(rawData) > 0 {

--- a/operations/server_switching_rule/delete_server_switching_rule_parameters.go
+++ b/operations/server_switching_rule/delete_server_switching_rule_parameters.go
@@ -125,7 +125,7 @@ func (o *DeleteServerSwitchingRuleParams) BindRequest(r *http.Request, route *mi
 // bindBackend binds and validates parameter Backend from query.
 func (o *DeleteServerSwitchingRuleParams) bindBackend(rawData []string, hasKey bool, formats strfmt.Registry) error {
 	if !hasKey {
-		return errors.Required("backend", "query")
+		return errors.Required("backend", "query", "")
 	}
 	var raw string
 	if len(rawData) > 0 {

--- a/operations/server_switching_rule/get_server_switching_rule_parameters.go
+++ b/operations/server_switching_rule/get_server_switching_rule_parameters.go
@@ -98,7 +98,7 @@ func (o *GetServerSwitchingRuleParams) BindRequest(r *http.Request, route *middl
 // bindBackend binds and validates parameter Backend from query.
 func (o *GetServerSwitchingRuleParams) bindBackend(rawData []string, hasKey bool, formats strfmt.Registry) error {
 	if !hasKey {
-		return errors.Required("backend", "query")
+		return errors.Required("backend", "query", "")
 	}
 	var raw string
 	if len(rawData) > 0 {

--- a/operations/server_switching_rule/get_server_switching_rules_parameters.go
+++ b/operations/server_switching_rule/get_server_switching_rules_parameters.go
@@ -87,7 +87,7 @@ func (o *GetServerSwitchingRulesParams) BindRequest(r *http.Request, route *midd
 // bindBackend binds and validates parameter Backend from query.
 func (o *GetServerSwitchingRulesParams) bindBackend(rawData []string, hasKey bool, formats strfmt.Registry) error {
 	if !hasKey {
-		return errors.Required("backend", "query")
+		return errors.Required("backend", "query", "")
 	}
 	var raw string
 	if len(rawData) > 0 {

--- a/operations/server_switching_rule/replace_server_switching_rule_parameters.go
+++ b/operations/server_switching_rule/replace_server_switching_rule_parameters.go
@@ -109,7 +109,7 @@ func (o *ReplaceServerSwitchingRuleParams) BindRequest(r *http.Request, route *m
 		var body models.ServerSwitchingRule
 		if err := route.Consumer.Consume(r.Body, &body); err != nil {
 			if err == io.EOF {
-				res = append(res, errors.Required("data", "body"))
+				res = append(res, errors.Required("data", "body", ""))
 			} else {
 				res = append(res, errors.NewParseError("data", "body", "", err))
 			}
@@ -124,7 +124,7 @@ func (o *ReplaceServerSwitchingRuleParams) BindRequest(r *http.Request, route *m
 			}
 		}
 	} else {
-		res = append(res, errors.Required("data", "body"))
+		res = append(res, errors.Required("data", "body", ""))
 	}
 	qForceReload, qhkForceReload, _ := qs.GetOK("force_reload")
 	if err := o.bindForceReload(qForceReload, qhkForceReload, route.Formats); err != nil {
@@ -155,7 +155,7 @@ func (o *ReplaceServerSwitchingRuleParams) BindRequest(r *http.Request, route *m
 // bindBackend binds and validates parameter Backend from query.
 func (o *ReplaceServerSwitchingRuleParams) bindBackend(rawData []string, hasKey bool, formats strfmt.Registry) error {
 	if !hasKey {
-		return errors.Required("backend", "query")
+		return errors.Required("backend", "query", "")
 	}
 	var raw string
 	if len(rawData) > 0 {

--- a/operations/sites/create_site_parameters.go
+++ b/operations/sites/create_site_parameters.go
@@ -93,7 +93,7 @@ func (o *CreateSiteParams) BindRequest(r *http.Request, route *middleware.Matche
 		var body models.Site
 		if err := route.Consumer.Consume(r.Body, &body); err != nil {
 			if err == io.EOF {
-				res = append(res, errors.Required("data", "body"))
+				res = append(res, errors.Required("data", "body", ""))
 			} else {
 				res = append(res, errors.NewParseError("data", "body", "", err))
 			}
@@ -108,7 +108,7 @@ func (o *CreateSiteParams) BindRequest(r *http.Request, route *middleware.Matche
 			}
 		}
 	} else {
-		res = append(res, errors.Required("data", "body"))
+		res = append(res, errors.Required("data", "body", ""))
 	}
 	qForceReload, qhkForceReload, _ := qs.GetOK("force_reload")
 	if err := o.bindForceReload(qForceReload, qhkForceReload, route.Formats); err != nil {

--- a/operations/sites/replace_site_parameters.go
+++ b/operations/sites/replace_site_parameters.go
@@ -98,7 +98,7 @@ func (o *ReplaceSiteParams) BindRequest(r *http.Request, route *middleware.Match
 		var body models.Site
 		if err := route.Consumer.Consume(r.Body, &body); err != nil {
 			if err == io.EOF {
-				res = append(res, errors.Required("data", "body"))
+				res = append(res, errors.Required("data", "body", ""))
 			} else {
 				res = append(res, errors.NewParseError("data", "body", "", err))
 			}
@@ -113,7 +113,7 @@ func (o *ReplaceSiteParams) BindRequest(r *http.Request, route *middleware.Match
 			}
 		}
 	} else {
-		res = append(res, errors.Required("data", "body"))
+		res = append(res, errors.Required("data", "body", ""))
 	}
 	qForceReload, qhkForceReload, _ := qs.GetOK("force_reload")
 	if err := o.bindForceReload(qForceReload, qhkForceReload, route.Formats); err != nil {

--- a/operations/stick_rule/create_stick_rule_parameters.go
+++ b/operations/stick_rule/create_stick_rule_parameters.go
@@ -104,7 +104,7 @@ func (o *CreateStickRuleParams) BindRequest(r *http.Request, route *middleware.M
 		var body models.StickRule
 		if err := route.Consumer.Consume(r.Body, &body); err != nil {
 			if err == io.EOF {
-				res = append(res, errors.Required("data", "body"))
+				res = append(res, errors.Required("data", "body", ""))
 			} else {
 				res = append(res, errors.NewParseError("data", "body", "", err))
 			}
@@ -119,7 +119,7 @@ func (o *CreateStickRuleParams) BindRequest(r *http.Request, route *middleware.M
 			}
 		}
 	} else {
-		res = append(res, errors.Required("data", "body"))
+		res = append(res, errors.Required("data", "body", ""))
 	}
 	qForceReload, qhkForceReload, _ := qs.GetOK("force_reload")
 	if err := o.bindForceReload(qForceReload, qhkForceReload, route.Formats); err != nil {
@@ -145,7 +145,7 @@ func (o *CreateStickRuleParams) BindRequest(r *http.Request, route *middleware.M
 // bindBackend binds and validates parameter Backend from query.
 func (o *CreateStickRuleParams) bindBackend(rawData []string, hasKey bool, formats strfmt.Registry) error {
 	if !hasKey {
-		return errors.Required("backend", "query")
+		return errors.Required("backend", "query", "")
 	}
 	var raw string
 	if len(rawData) > 0 {

--- a/operations/stick_rule/delete_stick_rule_parameters.go
+++ b/operations/stick_rule/delete_stick_rule_parameters.go
@@ -125,7 +125,7 @@ func (o *DeleteStickRuleParams) BindRequest(r *http.Request, route *middleware.M
 // bindBackend binds and validates parameter Backend from query.
 func (o *DeleteStickRuleParams) bindBackend(rawData []string, hasKey bool, formats strfmt.Registry) error {
 	if !hasKey {
-		return errors.Required("backend", "query")
+		return errors.Required("backend", "query", "")
 	}
 	var raw string
 	if len(rawData) > 0 {

--- a/operations/stick_rule/get_stick_rule_parameters.go
+++ b/operations/stick_rule/get_stick_rule_parameters.go
@@ -98,7 +98,7 @@ func (o *GetStickRuleParams) BindRequest(r *http.Request, route *middleware.Matc
 // bindBackend binds and validates parameter Backend from query.
 func (o *GetStickRuleParams) bindBackend(rawData []string, hasKey bool, formats strfmt.Registry) error {
 	if !hasKey {
-		return errors.Required("backend", "query")
+		return errors.Required("backend", "query", "")
 	}
 	var raw string
 	if len(rawData) > 0 {

--- a/operations/stick_rule/get_stick_rules_parameters.go
+++ b/operations/stick_rule/get_stick_rules_parameters.go
@@ -87,7 +87,7 @@ func (o *GetStickRulesParams) BindRequest(r *http.Request, route *middleware.Mat
 // bindBackend binds and validates parameter Backend from query.
 func (o *GetStickRulesParams) bindBackend(rawData []string, hasKey bool, formats strfmt.Registry) error {
 	if !hasKey {
-		return errors.Required("backend", "query")
+		return errors.Required("backend", "query", "")
 	}
 	var raw string
 	if len(rawData) > 0 {

--- a/operations/stick_rule/replace_stick_rule_parameters.go
+++ b/operations/stick_rule/replace_stick_rule_parameters.go
@@ -109,7 +109,7 @@ func (o *ReplaceStickRuleParams) BindRequest(r *http.Request, route *middleware.
 		var body models.StickRule
 		if err := route.Consumer.Consume(r.Body, &body); err != nil {
 			if err == io.EOF {
-				res = append(res, errors.Required("data", "body"))
+				res = append(res, errors.Required("data", "body", ""))
 			} else {
 				res = append(res, errors.NewParseError("data", "body", "", err))
 			}
@@ -124,7 +124,7 @@ func (o *ReplaceStickRuleParams) BindRequest(r *http.Request, route *middleware.
 			}
 		}
 	} else {
-		res = append(res, errors.Required("data", "body"))
+		res = append(res, errors.Required("data", "body", ""))
 	}
 	qForceReload, qhkForceReload, _ := qs.GetOK("force_reload")
 	if err := o.bindForceReload(qForceReload, qhkForceReload, route.Formats); err != nil {
@@ -155,7 +155,7 @@ func (o *ReplaceStickRuleParams) BindRequest(r *http.Request, route *middleware.
 // bindBackend binds and validates parameter Backend from query.
 func (o *ReplaceStickRuleParams) bindBackend(rawData []string, hasKey bool, formats strfmt.Registry) error {
 	if !hasKey {
-		return errors.Required("backend", "query")
+		return errors.Required("backend", "query", "")
 	}
 	var raw string
 	if len(rawData) > 0 {

--- a/operations/stick_table/get_stick_table_entries_parameters.go
+++ b/operations/stick_table/get_stick_table_entries_parameters.go
@@ -205,7 +205,7 @@ func (o *GetStickTableEntriesParams) bindOffset(rawData []string, hasKey bool, f
 // bindProcess binds and validates parameter Process from query.
 func (o *GetStickTableEntriesParams) bindProcess(rawData []string, hasKey bool, formats strfmt.Registry) error {
 	if !hasKey {
-		return errors.Required("process", "query")
+		return errors.Required("process", "query", "")
 	}
 	var raw string
 	if len(rawData) > 0 {
@@ -230,7 +230,7 @@ func (o *GetStickTableEntriesParams) bindProcess(rawData []string, hasKey bool, 
 // bindStickTable binds and validates parameter StickTable from query.
 func (o *GetStickTableEntriesParams) bindStickTable(rawData []string, hasKey bool, formats strfmt.Registry) error {
 	if !hasKey {
-		return errors.Required("stick_table", "query")
+		return errors.Required("stick_table", "query", "")
 	}
 	var raw string
 	if len(rawData) > 0 {

--- a/operations/stick_table/get_stick_table_parameters.go
+++ b/operations/stick_table/get_stick_table_parameters.go
@@ -104,7 +104,7 @@ func (o *GetStickTableParams) bindName(rawData []string, hasKey bool, formats st
 // bindProcess binds and validates parameter Process from query.
 func (o *GetStickTableParams) bindProcess(rawData []string, hasKey bool, formats strfmt.Registry) error {
 	if !hasKey {
-		return errors.Required("process", "query")
+		return errors.Required("process", "query", "")
 	}
 	var raw string
 	if len(rawData) > 0 {

--- a/operations/tcp_request_rule/create_tcp_request_rule_parameters.go
+++ b/operations/tcp_request_rule/create_tcp_request_rule_parameters.go
@@ -104,7 +104,7 @@ func (o *CreateTCPRequestRuleParams) BindRequest(r *http.Request, route *middlew
 		var body models.TCPRequestRule
 		if err := route.Consumer.Consume(r.Body, &body); err != nil {
 			if err == io.EOF {
-				res = append(res, errors.Required("data", "body"))
+				res = append(res, errors.Required("data", "body", ""))
 			} else {
 				res = append(res, errors.NewParseError("data", "body", "", err))
 			}
@@ -119,7 +119,7 @@ func (o *CreateTCPRequestRuleParams) BindRequest(r *http.Request, route *middlew
 			}
 		}
 	} else {
-		res = append(res, errors.Required("data", "body"))
+		res = append(res, errors.Required("data", "body", ""))
 	}
 	qForceReload, qhkForceReload, _ := qs.GetOK("force_reload")
 	if err := o.bindForceReload(qForceReload, qhkForceReload, route.Formats); err != nil {
@@ -178,7 +178,7 @@ func (o *CreateTCPRequestRuleParams) bindForceReload(rawData []string, hasKey bo
 // bindParentName binds and validates parameter ParentName from query.
 func (o *CreateTCPRequestRuleParams) bindParentName(rawData []string, hasKey bool, formats strfmt.Registry) error {
 	if !hasKey {
-		return errors.Required("parent_name", "query")
+		return errors.Required("parent_name", "query", "")
 	}
 	var raw string
 	if len(rawData) > 0 {
@@ -199,7 +199,7 @@ func (o *CreateTCPRequestRuleParams) bindParentName(rawData []string, hasKey boo
 // bindParentType binds and validates parameter ParentType from query.
 func (o *CreateTCPRequestRuleParams) bindParentType(rawData []string, hasKey bool, formats strfmt.Registry) error {
 	if !hasKey {
-		return errors.Required("parent_type", "query")
+		return errors.Required("parent_type", "query", "")
 	}
 	var raw string
 	if len(rawData) > 0 {

--- a/operations/tcp_request_rule/delete_tcp_request_rule_parameters.go
+++ b/operations/tcp_request_rule/delete_tcp_request_rule_parameters.go
@@ -177,7 +177,7 @@ func (o *DeleteTCPRequestRuleParams) bindIndex(rawData []string, hasKey bool, fo
 // bindParentName binds and validates parameter ParentName from query.
 func (o *DeleteTCPRequestRuleParams) bindParentName(rawData []string, hasKey bool, formats strfmt.Registry) error {
 	if !hasKey {
-		return errors.Required("parent_name", "query")
+		return errors.Required("parent_name", "query", "")
 	}
 	var raw string
 	if len(rawData) > 0 {
@@ -198,7 +198,7 @@ func (o *DeleteTCPRequestRuleParams) bindParentName(rawData []string, hasKey boo
 // bindParentType binds and validates parameter ParentType from query.
 func (o *DeleteTCPRequestRuleParams) bindParentType(rawData []string, hasKey bool, formats strfmt.Registry) error {
 	if !hasKey {
-		return errors.Required("parent_type", "query")
+		return errors.Required("parent_type", "query", "")
 	}
 	var raw string
 	if len(rawData) > 0 {

--- a/operations/tcp_request_rule/get_tcp_request_rule_parameters.go
+++ b/operations/tcp_request_rule/get_tcp_request_rule_parameters.go
@@ -127,7 +127,7 @@ func (o *GetTCPRequestRuleParams) bindIndex(rawData []string, hasKey bool, forma
 // bindParentName binds and validates parameter ParentName from query.
 func (o *GetTCPRequestRuleParams) bindParentName(rawData []string, hasKey bool, formats strfmt.Registry) error {
 	if !hasKey {
-		return errors.Required("parent_name", "query")
+		return errors.Required("parent_name", "query", "")
 	}
 	var raw string
 	if len(rawData) > 0 {
@@ -148,7 +148,7 @@ func (o *GetTCPRequestRuleParams) bindParentName(rawData []string, hasKey bool, 
 // bindParentType binds and validates parameter ParentType from query.
 func (o *GetTCPRequestRuleParams) bindParentType(rawData []string, hasKey bool, formats strfmt.Registry) error {
 	if !hasKey {
-		return errors.Required("parent_type", "query")
+		return errors.Required("parent_type", "query", "")
 	}
 	var raw string
 	if len(rawData) > 0 {

--- a/operations/tcp_request_rule/get_tcp_request_rules_parameters.go
+++ b/operations/tcp_request_rule/get_tcp_request_rules_parameters.go
@@ -97,7 +97,7 @@ func (o *GetTCPRequestRulesParams) BindRequest(r *http.Request, route *middlewar
 // bindParentName binds and validates parameter ParentName from query.
 func (o *GetTCPRequestRulesParams) bindParentName(rawData []string, hasKey bool, formats strfmt.Registry) error {
 	if !hasKey {
-		return errors.Required("parent_name", "query")
+		return errors.Required("parent_name", "query", "")
 	}
 	var raw string
 	if len(rawData) > 0 {
@@ -118,7 +118,7 @@ func (o *GetTCPRequestRulesParams) bindParentName(rawData []string, hasKey bool,
 // bindParentType binds and validates parameter ParentType from query.
 func (o *GetTCPRequestRulesParams) bindParentType(rawData []string, hasKey bool, formats strfmt.Registry) error {
 	if !hasKey {
-		return errors.Required("parent_type", "query")
+		return errors.Required("parent_type", "query", "")
 	}
 	var raw string
 	if len(rawData) > 0 {

--- a/operations/tcp_request_rule/replace_tcp_request_rule_parameters.go
+++ b/operations/tcp_request_rule/replace_tcp_request_rule_parameters.go
@@ -109,7 +109,7 @@ func (o *ReplaceTCPRequestRuleParams) BindRequest(r *http.Request, route *middle
 		var body models.TCPRequestRule
 		if err := route.Consumer.Consume(r.Body, &body); err != nil {
 			if err == io.EOF {
-				res = append(res, errors.Required("data", "body"))
+				res = append(res, errors.Required("data", "body", ""))
 			} else {
 				res = append(res, errors.NewParseError("data", "body", "", err))
 			}
@@ -124,7 +124,7 @@ func (o *ReplaceTCPRequestRuleParams) BindRequest(r *http.Request, route *middle
 			}
 		}
 	} else {
-		res = append(res, errors.Required("data", "body"))
+		res = append(res, errors.Required("data", "body", ""))
 	}
 	qForceReload, qhkForceReload, _ := qs.GetOK("force_reload")
 	if err := o.bindForceReload(qForceReload, qhkForceReload, route.Formats); err != nil {
@@ -207,7 +207,7 @@ func (o *ReplaceTCPRequestRuleParams) bindIndex(rawData []string, hasKey bool, f
 // bindParentName binds and validates parameter ParentName from query.
 func (o *ReplaceTCPRequestRuleParams) bindParentName(rawData []string, hasKey bool, formats strfmt.Registry) error {
 	if !hasKey {
-		return errors.Required("parent_name", "query")
+		return errors.Required("parent_name", "query", "")
 	}
 	var raw string
 	if len(rawData) > 0 {
@@ -228,7 +228,7 @@ func (o *ReplaceTCPRequestRuleParams) bindParentName(rawData []string, hasKey bo
 // bindParentType binds and validates parameter ParentType from query.
 func (o *ReplaceTCPRequestRuleParams) bindParentType(rawData []string, hasKey bool, formats strfmt.Registry) error {
 	if !hasKey {
-		return errors.Required("parent_type", "query")
+		return errors.Required("parent_type", "query", "")
 	}
 	var raw string
 	if len(rawData) > 0 {

--- a/operations/tcp_response_rule/create_tcp_response_rule_parameters.go
+++ b/operations/tcp_response_rule/create_tcp_response_rule_parameters.go
@@ -104,7 +104,7 @@ func (o *CreateTCPResponseRuleParams) BindRequest(r *http.Request, route *middle
 		var body models.TCPResponseRule
 		if err := route.Consumer.Consume(r.Body, &body); err != nil {
 			if err == io.EOF {
-				res = append(res, errors.Required("data", "body"))
+				res = append(res, errors.Required("data", "body", ""))
 			} else {
 				res = append(res, errors.NewParseError("data", "body", "", err))
 			}
@@ -119,7 +119,7 @@ func (o *CreateTCPResponseRuleParams) BindRequest(r *http.Request, route *middle
 			}
 		}
 	} else {
-		res = append(res, errors.Required("data", "body"))
+		res = append(res, errors.Required("data", "body", ""))
 	}
 	qForceReload, qhkForceReload, _ := qs.GetOK("force_reload")
 	if err := o.bindForceReload(qForceReload, qhkForceReload, route.Formats); err != nil {
@@ -145,7 +145,7 @@ func (o *CreateTCPResponseRuleParams) BindRequest(r *http.Request, route *middle
 // bindBackend binds and validates parameter Backend from query.
 func (o *CreateTCPResponseRuleParams) bindBackend(rawData []string, hasKey bool, formats strfmt.Registry) error {
 	if !hasKey {
-		return errors.Required("backend", "query")
+		return errors.Required("backend", "query", "")
 	}
 	var raw string
 	if len(rawData) > 0 {

--- a/operations/tcp_response_rule/delete_tcp_response_rule_parameters.go
+++ b/operations/tcp_response_rule/delete_tcp_response_rule_parameters.go
@@ -125,7 +125,7 @@ func (o *DeleteTCPResponseRuleParams) BindRequest(r *http.Request, route *middle
 // bindBackend binds and validates parameter Backend from query.
 func (o *DeleteTCPResponseRuleParams) bindBackend(rawData []string, hasKey bool, formats strfmt.Registry) error {
 	if !hasKey {
-		return errors.Required("backend", "query")
+		return errors.Required("backend", "query", "")
 	}
 	var raw string
 	if len(rawData) > 0 {

--- a/operations/tcp_response_rule/get_tcp_response_rule_parameters.go
+++ b/operations/tcp_response_rule/get_tcp_response_rule_parameters.go
@@ -98,7 +98,7 @@ func (o *GetTCPResponseRuleParams) BindRequest(r *http.Request, route *middlewar
 // bindBackend binds and validates parameter Backend from query.
 func (o *GetTCPResponseRuleParams) bindBackend(rawData []string, hasKey bool, formats strfmt.Registry) error {
 	if !hasKey {
-		return errors.Required("backend", "query")
+		return errors.Required("backend", "query", "")
 	}
 	var raw string
 	if len(rawData) > 0 {

--- a/operations/tcp_response_rule/get_tcp_response_rules_parameters.go
+++ b/operations/tcp_response_rule/get_tcp_response_rules_parameters.go
@@ -87,7 +87,7 @@ func (o *GetTCPResponseRulesParams) BindRequest(r *http.Request, route *middlewa
 // bindBackend binds and validates parameter Backend from query.
 func (o *GetTCPResponseRulesParams) bindBackend(rawData []string, hasKey bool, formats strfmt.Registry) error {
 	if !hasKey {
-		return errors.Required("backend", "query")
+		return errors.Required("backend", "query", "")
 	}
 	var raw string
 	if len(rawData) > 0 {

--- a/operations/tcp_response_rule/replace_tcp_response_rule_parameters.go
+++ b/operations/tcp_response_rule/replace_tcp_response_rule_parameters.go
@@ -109,7 +109,7 @@ func (o *ReplaceTCPResponseRuleParams) BindRequest(r *http.Request, route *middl
 		var body models.TCPResponseRule
 		if err := route.Consumer.Consume(r.Body, &body); err != nil {
 			if err == io.EOF {
-				res = append(res, errors.Required("data", "body"))
+				res = append(res, errors.Required("data", "body", ""))
 			} else {
 				res = append(res, errors.NewParseError("data", "body", "", err))
 			}
@@ -124,7 +124,7 @@ func (o *ReplaceTCPResponseRuleParams) BindRequest(r *http.Request, route *middl
 			}
 		}
 	} else {
-		res = append(res, errors.Required("data", "body"))
+		res = append(res, errors.Required("data", "body", ""))
 	}
 	qForceReload, qhkForceReload, _ := qs.GetOK("force_reload")
 	if err := o.bindForceReload(qForceReload, qhkForceReload, route.Formats); err != nil {
@@ -155,7 +155,7 @@ func (o *ReplaceTCPResponseRuleParams) BindRequest(r *http.Request, route *middl
 // bindBackend binds and validates parameter Backend from query.
 func (o *ReplaceTCPResponseRuleParams) bindBackend(rawData []string, hasKey bool, formats strfmt.Registry) error {
 	if !hasKey {
-		return errors.Required("backend", "query")
+		return errors.Required("backend", "query", "")
 	}
 	var raw string
 	if len(rawData) > 0 {

--- a/operations/transactions/start_transaction_parameters.go
+++ b/operations/transactions/start_transaction_parameters.go
@@ -79,7 +79,7 @@ func (o *StartTransactionParams) BindRequest(r *http.Request, route *middleware.
 // bindVersion binds and validates parameter Version from query.
 func (o *StartTransactionParams) bindVersion(rawData []string, hasKey bool, formats strfmt.Registry) error {
 	if !hasKey {
-		return errors.Required("version", "query")
+		return errors.Required("version", "query", "")
 	}
 	var raw string
 	if len(rawData) > 0 {


### PR DESCRIPTION
In our packaging of dataplaneapi in Fedora 33, we found that go-openapi/errors was updated in the distro such that dataplaneapi would no longer compile.  It appears that it is related to the following commit:
https://github.com/go-openapi/errors/commit/07f65d36d3b56d4b56744489fe52f01425fe7028
The changes in this pull request allow us to once again build dataplaneapi against go-openapi/errors v0.19.6