### PR TITLE
Makefile: add stripped and packed/compressed binary targets suitable for embedded envs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,9 +22,9 @@ build:
 	CGO_ENABLED=0 go build -gcflags "-N -l" -ldflags "-X main.GitRepo=${GIT_REPO} -X main.GitTag=${GIT_LAST_TAG} -X main.GitCommit=${GIT_HEAD_COMMIT} -X main.GitDirty=${GIT_MODIFIED} -X main.BuildTime=${BUILD_DATE}" -o ${DATAPLANEAPI_PATH}/build/dataplaneapi ${DATAPLANEAPI_PATH}/cmd/dataplaneapi/
 experimental-minified-build:
 	mkdir -p ${DATAPLANEAPI_PATH}/build
-	CGO_ENABLED=0 go build -gcflags "-N -l" -ldflags "-X main.GitRepo=${GIT_REPO} -X main.GitTag=${GIT_LAST_TAG} -X main.GitCommit=${GIT_HEAD_COMMIT} -X main.GitDirty=${GIT_MODIFIED} -X main.BuildTime=${BUILD_DATE}" -o ${DATAPLANEAPI_PATH}/build/dataplaneapi ${DATAPLANEAPI_PATH}/cmd/dataplaneapi/
+	CGO_ENABLED=0 go build -gcflags "-N -l" -ldflags "-s -w -X main.GitRepo=${GIT_REPO} -X main.GitTag=${GIT_LAST_TAG} -X main.GitCommit=${GIT_HEAD_COMMIT} -X main.GitDirty=${GIT_MODIFIED} -X main.BuildTime=${BUILD_DATE}" -o ${DATAPLANEAPI_PATH}/build/dataplaneapi ${DATAPLANEAPI_PATH}/cmd/dataplaneapi/
 	upx --best --overlay=strip ${DATAPLANEAPI_PATH}/build/dataplaneapi
 experimental-minified-build-ultra-brute:
 	mkdir -p ${DATAPLANEAPI_PATH}/build
-	CGO_ENABLED=0 go build -gcflags "-N -l" -ldflags "-X main.GitRepo=${GIT_REPO} -X main.GitTag=${GIT_LAST_TAG} -X main.GitCommit=${GIT_HEAD_COMMIT} -X main.GitDirty=${GIT_MODIFIED} -X main.BuildTime=${BUILD_DATE}" -o ${DATAPLANEAPI_PATH}/build/dataplaneapi ${DATAPLANEAPI_PATH}/cmd/dataplaneapi/
+	CGO_ENABLED=0 go build -gcflags "-N -l" -ldflags "-s -w -X main.GitRepo=${GIT_REPO} -X main.GitTag=${GIT_LAST_TAG} -X main.GitCommit=${GIT_HEAD_COMMIT} -X main.GitDirty=${GIT_MODIFIED} -X main.BuildTime=${BUILD_DATE}" -o ${DATAPLANEAPI_PATH}/build/dataplaneapi ${DATAPLANEAPI_PATH}/cmd/dataplaneapi/
 	upx --ultra-brute --overlay=strip ${DATAPLANEAPI_PATH}/build/dataplaneapi

--- a/Makefile
+++ b/Makefile
@@ -20,3 +20,11 @@ clean:
 build:
 	mkdir -p ${DATAPLANEAPI_PATH}/build
 	CGO_ENABLED=0 go build -gcflags "-N -l" -ldflags "-X main.GitRepo=${GIT_REPO} -X main.GitTag=${GIT_LAST_TAG} -X main.GitCommit=${GIT_HEAD_COMMIT} -X main.GitDirty=${GIT_MODIFIED} -X main.BuildTime=${BUILD_DATE}" -o ${DATAPLANEAPI_PATH}/build/dataplaneapi ${DATAPLANEAPI_PATH}/cmd/dataplaneapi/
+experimental-minified-build:
+	mkdir -p ${DATAPLANEAPI_PATH}/build
+	CGO_ENABLED=0 go build -gcflags "-N -l" -ldflags "-X main.GitRepo=${GIT_REPO} -X main.GitTag=${GIT_LAST_TAG} -X main.GitCommit=${GIT_HEAD_COMMIT} -X main.GitDirty=${GIT_MODIFIED} -X main.BuildTime=${BUILD_DATE}" -o ${DATAPLANEAPI_PATH}/build/dataplaneapi ${DATAPLANEAPI_PATH}/cmd/dataplaneapi/
+	upx --best --overlay=strip ${DATAPLANEAPI_PATH}/build/dataplaneapi
+experimental-minified-build-ultra-brute:
+	mkdir -p ${DATAPLANEAPI_PATH}/build
+	CGO_ENABLED=0 go build -gcflags "-N -l" -ldflags "-X main.GitRepo=${GIT_REPO} -X main.GitTag=${GIT_LAST_TAG} -X main.GitCommit=${GIT_HEAD_COMMIT} -X main.GitDirty=${GIT_MODIFIED} -X main.BuildTime=${BUILD_DATE}" -o ${DATAPLANEAPI_PATH}/build/dataplaneapi ${DATAPLANEAPI_PATH}/cmd/dataplaneapi/
+	upx --ultra-brute --overlay=strip ${DATAPLANEAPI_PATH}/build/dataplaneapi


### PR DESCRIPTION
Greetings,

To better support embedded systems with limited flash storage, this pull request introduces optional build
targets that take advantage of several space-saving features.

The space savings are significant - the default target produces a 25MB dataplaneapi binary, while the binary produced by the experimental-minified-build-ultra-brute build target being introduced produces a 4.2MB binary.

There's plenty of opportunity to optimize the space usage further, but the below patches should provide a
good starting point to investigate further.
