### PR TITLE
BUG/MAJOR: service-discovery: Use Consul Node.Address when Service.Address is empty

### DIFF
--- a/discovery/consul_service_discovery_instance.go
+++ b/discovery/consul_service_discovery_instance.go
@@ -147,10 +147,17 @@ func (c *consulInstance) updateServices() error {
 func (c *consulInstance) convertToServers(nodes []*api.ServiceEntry) []configuration.ServiceServer {
 	servers := make([]configuration.ServiceServer, 0)
 	for _, node := range nodes {
-		servers = append(servers, configuration.ServiceServer{
-			Address: node.Service.Address,
-			Port:    node.Service.Port,
-		})
+		if node.Service.Address != "" {
+			servers = append(servers, configuration.ServiceServer{
+				Address: node.Service.Address,
+				Port:    node.Service.Port,
+			})
+		} else {
+			servers = append(servers, configuration.ServiceServer{
+				Address: node.Node.Address,
+				Port:    node.Service.Port,
+			})
+		}
 	}
 	return servers
 }


### PR DESCRIPTION
According to the Consul documentation [1] the Service address is not required. When the Service address is not specified it results in the catalog entry being an empty string.

```
"Service": {
    "ID": "api",
    "Service": "api",
    "Tags": [],
    "Address": "",
    ...
}
```

When this happens, the current service discovery mechanism will add the service without any IP:

```
backend consul-backend-192.168.1.22-8500-api
  server SRV_D0YGR :80 weight 128
```

This patch falls back to the nodes address when the service address is empty. This was also suggested within a bug report [2] filed within the Consul repo.

[1] https://www.consul.io/docs/discovery/services#service-definition
[2] https://github.com/hashicorp/consul/issues/2076