### PR TITLE
BUG/MINOR: discovery: Handle config error from existing AWS server

### DIFF
--- a/discovery/aws_service_discovery_instance.go
+++ b/discovery/aws_service_discovery_instance.go
@@ -148,7 +148,17 @@ func (a *awsInstance) start() {
 					a.stop()
 				}
 				if err = a.updateServices(api); err != nil {
-					a.stop()
+					switch t := err.(type) {
+					case *configuration.ConfError:
+						switch t.Code() {
+						case configuration.ErrObjectAlreadyExists:
+							continue
+						default:
+							a.stop()
+						}
+					default:
+						a.stop()
+					}
 				}
 			case <-a.ctx.Done():
 				return

--- a/discovery/service_discovery_instance.go
+++ b/discovery/service_discovery_instance.go
@@ -89,7 +89,9 @@ func (s *ServiceDiscoveryInstance) UpdateServices(services []ServiceInstance) er
 			continue
 		}
 		if !service.Changed() {
-			s.services[service.GetName()].deleted = false
+			if se, ok := s.services[service.GetName()]; ok {
+				se.deleted = false
+			}
 			continue
 		}
 		r, err := s.initService(service)


### PR DESCRIPTION
This fixes #186 where if a server already exists then the AWS
service discovery job is stopped. This catches that case and keeps
the job running. It also introduces a check for a service key name
before referencing as without it there was a nil pointer dereference
runtime error.