### PR TITLE
BUG/MINOR: discovery: Update AWS growth type default to exponential

### DIFF
--- a/discovery/utils.go
+++ b/discovery/utils.go
@@ -45,7 +45,7 @@ func ValidateAWSData(data *models.AwsRegion, useValidation bool) error {
 		data.ServerSlotsBase = misc.Int64P(10)
 	}
 	if data.ServerSlotsGrowthType == nil {
-		data.ServerSlotsGrowthType = misc.StringP(models.AwsRegionServerSlotsGrowthTypeLinear)
+		data.ServerSlotsGrowthType = misc.StringP(models.AwsRegionServerSlotsGrowthTypeExponential)
 	}
 	if *data.ServerSlotsGrowthType == models.AwsRegionServerSlotsGrowthTypeLinear && (data.ServerSlotsGrowthIncrement == 0 || data.ServerSlotsGrowthIncrement < minimumServerSlotsBase) {
 		data.ServerSlotsGrowthIncrement = minimumServerSlotsBase


### PR DESCRIPTION
The specification for the AWS service discovery integration says
that the growth type should be "exponential", however, it was being
set to "linear". This patch corrects that and aligns the default
with the specification.