### PR TITLE
BUG/MINOR: discovery: AWS handle version mismatch

### DIFF
--- a/discovery/aws_service_discovery_instance.go
+++ b/discovery/aws_service_discovery_instance.go
@@ -168,6 +168,8 @@ func (a *awsInstance) start() {
 						switch t.Code() {
 						case configuration.ErrObjectAlreadyExists:
 							continue
+						case configuration.ErrVersionMismatch:
+							continue
 						default:
 							a.stop()
 						}


### PR DESCRIPTION
When multiple AWS regions/clusters are specified and the
HAProxy Data Plane API attempts to update them at the same time it
is possible that one of the transactions is still in process when
another transaction is initiated. This causes the version ID to not
have been incremented yet, which can cause a version mismatch error.
This patch catches the configuration.ErrVersionMismatch error and
allows the transaction to be attempted again, which allows it to
get the latest version.

This fixes #194.