### PR TITLE
Setting backend servers to an empty list upon ServiceDiscovery deletion

### DIFF
--- a/discovery/aws_service_discovery_instance.go
+++ b/discovery/aws_service_discovery_instance.go
@@ -97,15 +97,18 @@ func newAWSRegionInstance(ctx context.Context, params *models.AwsRegion, client 
 		return nil, err
 	}
 
+	log := log.WithFields(log.Fields{"ServiceDiscovery": "AWS", "ID": *params.ID})
+
 	ai := &awsInstance{
 		params:  params,
 		timeout: timeout,
 		ctx:     ctx,
-		log:     log.WithFields(log.Fields{"ServiceDiscovery": "AWS", "ID": *params.ID}),
+		log:     log,
 		state:   make(map[string]map[string]time.Time),
 		discoveryConfig: NewServiceDiscoveryInstance(client, reloadAgent, discoveryInstanceParams{
 			Allowlist:       []string{},
 			Denylist:        []string{},
+			Log:             log,
 			ServerSlotsBase: int(*params.ServerSlotsBase),
 			SlotsGrowthType: *params.ServerSlotsGrowthType,
 			SlotsIncrement:  int(params.ServerSlotsGrowthIncrement),
@@ -155,6 +158,7 @@ func (a *awsInstance) start() {
 				err := a.discoveryConfig.UpdateParams(discoveryInstanceParams{
 					Allowlist:       []string{},
 					Denylist:        []string{},
+					Log:             log.WithFields(log.Fields{"ServiceDiscovery": "AWS", "ID": *a.params.ID}),
 					ServerSlotsBase: int(*a.params.ServerSlotsBase),
 					SlotsGrowthType: *a.params.ServerSlotsGrowthType,
 					SlotsIncrement:  int(a.params.ServerSlotsGrowthIncrement),

--- a/discovery/consul_service_discovery.go
+++ b/discovery/consul_service_discovery.go
@@ -56,6 +56,8 @@ func (c *consulServiceDiscovery) AddNode(id string, params ServiceDiscoveryParam
 		return err
 	}
 
+	log := log.WithFields(log.Fields{"ServiceDiscovery": "Consul", "ID": *cParams.ID})
+
 	instance := &consulInstance{
 		params:  cParams,
 		ctx:     c.context,
@@ -63,12 +65,13 @@ func (c *consulServiceDiscovery) AddNode(id string, params ServiceDiscoveryParam
 		discoveryConfig: NewServiceDiscoveryInstance(c.client, c.reloadAgent, discoveryInstanceParams{
 			Allowlist:       cParams.ServiceWhitelist,
 			Denylist:        cParams.ServiceBlacklist,
+			Log:             log,
 			ServerSlotsBase: int(*cParams.ServerSlotsBase),
 			SlotsGrowthType: *cParams.ServerSlotsGrowthType,
 			SlotsIncrement:  int(cParams.ServerSlotsGrowthIncrement),
 		}),
 		prevIndexes: make(map[string]uint64),
-		log:         log.WithFields(log.Fields{"ServiceDiscovery": "Consul", "ID": *cParams.ID}),
+		log:         log,
 	}
 
 	if err = c.consulServices.Create(id, instance); err != nil {

--- a/discovery/consul_service_discovery_instance.go
+++ b/discovery/consul_service_discovery_instance.go
@@ -100,6 +100,7 @@ func (c *consulInstance) watch() {
 			err := c.discoveryConfig.UpdateParams(discoveryInstanceParams{
 				Allowlist:       c.params.ServiceAllowlist,
 				Denylist:        c.params.ServiceDenylist,
+				Log:             log.WithFields(log.Fields{"ServiceDiscovery": "Consul", "ID": *c.params.ID}),
 				ServerSlotsBase: int(*c.params.ServerSlotsBase),
 				SlotsGrowthType: *c.params.ServerSlotsGrowthType,
 				SlotsIncrement:  int(c.params.ServerSlotsGrowthIncrement),

--- a/discovery/service_discovery_instance_test.go
+++ b/discovery/service_discovery_instance_test.go
@@ -82,8 +82,18 @@ func TestAWS(t *testing.T) {
 	err = confClient.Init(confParams)
 	assert.Nil(t, err)
 
-	ra := &haproxy.ReloadAgent{}
-	assert.Nil(t, ra.Init(1, "true", "true", cfgFile, "", 1))
+	var ra haproxy.IReloadAgent
+
+	ra, err = haproxy.NewReloadAgent(haproxy.ReloadAgentParams{
+		Delay:      1,
+		ReloadCmd:  "true",
+		RestartCmd: "true",
+		ConfigFile: cfgFile,
+		BackupDir:  tmp,
+		Retention:  0,
+		Ctx:        context.Background(),
+	})
+	assert.Nil(t, err)
 
 	var instance *awsInstance
 	instance, err = newAWSRegionInstance(context.Background(), &models.AwsRegion{


### PR DESCRIPTION
Closes #200.

The proposed solution is to set an empty `servers` section to the no more tracked backends by Service Discovery, and logging it to the desired target to let the end-users adopting the preferred clean-up strategy.

The resulting output of the log is the following, YMMV.

```json
{
	"ServiceDiscovery": "AWS",
	"ID": "0e1eb609-d7c8-49b8-b51f-25d30859b4e2",
	"level": "warning",
	"msg": "service my-app-8080 marked for clean-up, has not any more backend servers",
	"time": "2021-08-25T10:27:50+02:00"
}
```

> Example refers to AWS Service Discovery although the original bug report is referencing Consul but the underlying implementations are the same.

In the original issue report, the suggested fix was commenting the `frontends` using the `backends` discovered by Service Discovery but this approach was too much opinionated and invasive since these could be used in several places like backend switching rules, maps, or `use_backend`, making this search-and-replace cleanup functions time and resource-intensive.