### PR TITLE
BUG/MEDIUM: reload agent: fix race conditions in the reload agent

### DIFF
--- a/haproxy/reload_agent_test.go
+++ b/haproxy/reload_agent_test.go
@@ -1,0 +1,75 @@
+// Copyright 2019 HAProxy Technologies
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package haproxy
+
+import (
+	"context"
+	"io/ioutil"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestReloadAgentDoesntMissReloads(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	f, err := ioutil.TempFile("", "config.cfg")
+	assert.Nil(t, err)
+	assert.NotNil(t, f)
+	t.Cleanup(func() {
+		cancel()
+		assert.Nil(t, os.Remove(f.Name()))
+	})
+
+	reloadAgentParams := ReloadAgentParams{
+		Delay:      1,
+		ReloadCmd:  `echo "systemctl reload haproxy"`,
+		RestartCmd: `echo "systemctl restart haproxy"`,
+		ConfigFile: f.Name(),
+		BackupDir:  "",
+		Retention:  1,
+		Ctx:        ctx,
+	}
+
+	ra, err := NewReloadAgent(reloadAgentParams)
+	assert.Nil(t, err)
+	assert.NotNil(t, ra)
+
+	var reloadID, firstReloadID, secondReloadID string
+
+	// trigger a reload
+	reloadID = ra.Reload()
+	assert.NotEmpty(t, reloadID)
+	firstReloadID = reloadID
+
+	// trigger another reload shortly after the first one but before the
+	// delay has elapsed which should yield the first reload ID
+	time.Sleep(10 * time.Millisecond)
+	reloadID = ra.Reload()
+	assert.EqualValues(t, firstReloadID, reloadID)
+
+	// sleep for as long as the delay duration to mimic a slightly
+	// slower DataplaneAPI operation
+	time.Sleep(time.Duration(reloadAgentParams.Delay) * time.Second)
+
+	// Since this is happening after the delay has elapsed, it should create
+	// a new reload ID
+	reloadID = ra.Reload()
+	assert.NotEmpty(t, reloadID)
+	secondReloadID = reloadID
+	assert.NotEqualValues(t, firstReloadID, secondReloadID)
+}


### PR DESCRIPTION
Hi, 

We have noticed an issue with dataplaneapi accepting transactions and updating the configuration file on the file system, but not actually applying the configuration after that (the /stats page doesn't contain all expected frontends and HAProxy doesn't accept connections).
It happens when a few transactions (let's say 10, but the number doesn't really matter) are committed in quick succession and some of them happen right after a reload has been initiated by the antecedent transactions. This is happening because `ra.cache.next = ""` is part of a `defer` statement which gets executed after the `time.Sleep()` so we can only queue a new transaction after the delay has elapsed (which is 5 seconds in our case).  In practice this means in that interval of 5 seconds after a reload it's not possible to schedule a reload and any transactions committed during that period might not actually get  applied. An alternative approach is to use a `time.Ticker` which doesn't require channels and `time.Sleep` and only reloads if necessary (i.e. `Reload()` has been called at least once between the ticks).

There were also a few race conditions due to accessing `ra.cache.next` without a mutex which have been addressed.
The test provided can be run against the original implementation and it should fail, especially if run a few times (e.g. with `-count 10`),

