### PR TITLE
FEATURE/MINOR: Consul: Add service regexp filter

### DIFF
--- a/discovery/consul_service_discovery_instance.go
+++ b/discovery/consul_service_discovery_instance.go
@@ -18,6 +18,7 @@ package discovery
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"time"
 
 	"github.com/haproxytech/client-native/v3/configuration"
@@ -144,9 +145,14 @@ func (c *consulInstance) updateServices() error {
 	if err != nil {
 		return err
 	}
+	re := regexp.MustCompile(c.params.Regexp)
 	newIndexes := make(map[string]uint64)
 	for se := range cServices {
 		if se == "consul" {
+			continue
+		}
+		match := re.MatchString(se)
+		if !match {
 			continue
 		}
 		nodes, meta, err := c.api.Health().Service(se, "", false, &api.QueryOptions{})


### PR DESCRIPTION
Hello, it seems to be good to have regexp filter for consul services, since "Namespace" filtering in consul is only in enterprise version