### PR TITLE
Bug/Minor: Remove sockpair from HAPROXY_MASTER_CLI

### DIFF
--- a/configure_data_plane.go
+++ b/configure_data_plane.go
@@ -123,6 +123,12 @@ func configureAPI(api *operations.DataPlaneAPI) http.Handler { //nolint:cyclop,m
 		masterRuntime := os.Getenv("HAPROXY_MASTER_CLI")
 		if misc.IsUnixSocketAddr(masterRuntime) {
 			haproxyOptions.MasterRuntime = strings.Replace(masterRuntime, "unix@", "", 1)
+			if strings.Contains(haproxyOptions.MasterRuntime, "sockpair@") {
+				semikolon := strings.Index(haproxyOptions.MasterRuntime, ";")
+				if semikolon != -1 {
+					haproxyOptions.MasterRuntime = haproxyOptions.MasterRuntime[:semikolon]
+				}
+			}
 		}
 	}
 


### PR DESCRIPTION
With commit https://github.com/haproxy/haproxy/commit/8a02257d88276e2f2f10c407d2961995f74a192c was the `sockpair@` added to the master socket.

fix: https://github.com/haproxytech/dataplaneapi/issues/329