### PR TITLE
MINOR: Add Subject and Serial to certificate response

### DIFF
--- a/handlers/ssl_cert_storage.go
+++ b/handlers/ssl_cert_storage.go
@@ -97,6 +97,8 @@ func (h *StorageGetOneStorageSSLCertificateHandlerImpl) Handle(params storage.Ge
 		Issuers:     info.Issuers,
 		Domains:     info.DNS,
 		IPAddresses: info.IPs,
+		Subject:     info.Subject,
+		Serial:      info.Serial,
 	}
 	return storage.NewGetOneStorageSSLCertificateOK().WithPayload(retf)
 }
@@ -208,6 +210,8 @@ func (h *StorageReplaceStorageSSLCertificateHandlerImpl) Handle(params storage.R
 		Issuers:     info.Issuers,
 		Domains:     info.DNS,
 		IPAddresses: info.IPs,
+		Subject:     info.Subject,
+		Serial:      info.Serial,
 	}
 
 	skipReload := false
@@ -273,6 +277,8 @@ func (h *StorageCreateStorageSSLCertificateHandlerImpl) Handle(params storage.Cr
 		Issuers:     info.Issuers,
 		Domains:     info.DNS,
 		IPAddresses: info.IPs,
+		Subject:     info.Subject,
+		Serial:      info.Serial,
 	}
 
 	forceReload := false


### PR DESCRIPTION
`models.CertificateInfo` is already used in the response, but the `Subject` and `Serial` fields are not included in the response. This change adds them to the response.

This shouldn't provide an issue, as _every_ certificate in existence requires a `Subject` and a `Serial`. I welcome comments :)