### PR TITLE
Don't panic on missing command

### DIFF
--- a/runtime/serve.go
+++ b/runtime/serve.go
@@ -36,6 +36,9 @@ func serve(comm *Commands, conn net.Conn) {
 
 	cmd := strings.Fields(string(data))
 	c, ok := comm.Get(cmd[0])
+	if len(cmd) < 1 {
+		cmd = []string{"help"}
+	}
 	if cmd[0] == "exit" {
 		return
 	}


### PR DESCRIPTION
This PR adds a check for missing command and returns `help` instead of exiting with a `panic`.

Prevents:
```
panic: runtime error: index out of range [0] with length 0

goroutine 27 [running]:
github.com/haproxytech/dataplaneapi/runtime.serve(0xc00033e0c8, {0x1edc2e0, 0xc00578e100})
	github.com/haproxytech/dataplaneapi/runtime/serve.go:38 +0x5a5
created by github.com/haproxytech/dataplaneapi/runtime.(*DebugServer).Start.func2 in goroutine 74
	github.com/haproxytech/dataplaneapi/runtime/runtime.go:102 +0x4e
```