### PR TITLE
BUG/MINOR: handlers: populate sha256_finger_print in SSL certificate responses

### DIFF
--- a/handlers/ssl_cert_storage.go
+++ b/handlers/ssl_cert_storage.go
@@ -91,17 +91,18 @@ func (h *StorageGetOneStorageSSLCertificateHandlerImpl) Handle(params storage.Ge
 		return storage.NewGetOneStorageSSLCertificateDefault(int(*e.Code)).WithPayload(e)
 	}
 	retf := &models.SslCertificate{
-		File:        filename,
-		Description: "managed SSL file",
-		StorageName: filepath.Base(filename),
-		Size:        &size,
-		NotAfter:    (*strfmt.DateTime)(info.NotAfter),
-		NotBefore:   (*strfmt.DateTime)(info.NotBefore),
-		Issuers:     info.Issuers,
-		Domains:     info.DNS,
-		IPAddresses: info.IPs,
-		Subject:     info.Subject,
-		Serial:      info.Serial,
+		File:              filename,
+		Description:       "managed SSL file",
+		StorageName:       filepath.Base(filename),
+		Size:              &size,
+		NotAfter:          (*strfmt.DateTime)(info.NotAfter),
+		NotBefore:         (*strfmt.DateTime)(info.NotBefore),
+		Issuers:           info.Issuers,
+		Domains:           info.DNS,
+		IPAddresses:       info.IPs,
+		Subject:           info.Subject,
+		Serial:            info.Serial,
+		Sha256FingerPrint: info.Sha256FingerPrint,
 	}
 	return storage.NewGetOneStorageSSLCertificateOK().WithPayload(retf)
 }
@@ -211,17 +212,18 @@ func (h *StorageReplaceStorageSSLCertificateHandlerImpl) Handle(params storage.R
 		return storage.NewReplaceStorageSSLCertificateDefault(int(*e.Code)).WithPayload(e)
 	}
 	retf := &models.SslCertificate{
-		File:        filename,
-		Description: "managed SSL file",
-		StorageName: filepath.Base(filename),
-		Size:        misc.Int64P(len(params.Data)),
-		NotAfter:    (*strfmt.DateTime)(info.NotAfter),
-		NotBefore:   (*strfmt.DateTime)(info.NotBefore),
-		Issuers:     info.Issuers,
-		Domains:     info.DNS,
-		IPAddresses: info.IPs,
-		Subject:     info.Subject,
-		Serial:      info.Serial,
+		File:              filename,
+		Description:       "managed SSL file",
+		StorageName:       filepath.Base(filename),
+		Size:              misc.Int64P(len(params.Data)),
+		NotAfter:          (*strfmt.DateTime)(info.NotAfter),
+		NotBefore:         (*strfmt.DateTime)(info.NotBefore),
+		Issuers:           info.Issuers,
+		Domains:           info.DNS,
+		IPAddresses:       info.IPs,
+		Subject:           info.Subject,
+		Serial:            info.Serial,
+		Sha256FingerPrint: info.Sha256FingerPrint,
 	}
 
 	skipReload := false
@@ -295,17 +297,18 @@ func (h *StorageCreateStorageSSLCertificateHandlerImpl) Handle(params storage.Cr
 		return storage.NewCreateStorageSSLCertificateDefault(int(*e.Code)).WithPayload(e)
 	}
 	retf := &models.SslCertificate{
-		File:        filename,
-		Description: "managed SSL file",
-		StorageName: filepath.Base(filename),
-		Size:        &size,
-		NotAfter:    (*strfmt.DateTime)(info.NotAfter),
-		NotBefore:   (*strfmt.DateTime)(info.NotBefore),
-		Issuers:     info.Issuers,
-		Domains:     info.DNS,
-		IPAddresses: info.IPs,
-		Subject:     info.Subject,
-		Serial:      info.Serial,
+		File:              filename,
+		Description:       "managed SSL file",
+		StorageName:       filepath.Base(filename),
+		Size:              &size,
+		NotAfter:          (*strfmt.DateTime)(info.NotAfter),
+		NotBefore:         (*strfmt.DateTime)(info.NotBefore),
+		Issuers:           info.Issuers,
+		Domains:           info.DNS,
+		IPAddresses:       info.IPs,
+		Subject:           info.Subject,
+		Serial:            info.Serial,
+		Sha256FingerPrint: info.Sha256FingerPrint,
 	}
 
 	skipReload := false


### PR DESCRIPTION
The SSL certificate storage handlers were not copying the Sha256FingerPrint field from GetCertificatesInfo() to the API response, even though the field is available in client-native's CertificatesInfo struct and the field is [defined in the OpenAPI spec](https://www.haproxy.com/documentation/dataplaneapi/community/?v=v3#get-/services/haproxy/storage/ssl_certificates/-name-).