### PR TITLE
validate_params

### DIFF
--- a/handlers/respond/respond.go
+++ b/handlers/respond/respond.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"reflect"
 	"strings"
 
 	"github.com/go-chi/chi/v5"
@@ -202,13 +203,175 @@ func DecodeBody[T interface {
 // structs that have no Validate method; client-native models embedded in such
 // a body should still be validated individually (see Unprocessable).
 func DecodeJSON(r *http.Request, w http.ResponseWriter, out any) bool {
-	dec := json.NewDecoder(r.Body)
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		BadRequest(w, err.Error())
+		return false
+	}
+
+	if err := strictUnknownFieldsCheck(body, out); err != nil {
+		log.Warningf("STRICT JSON UNKNOWN FIELD ERROR: %v", err)
+		BadRequest(w, err.Error())
+		return false
+	}
+
+	dec := json.NewDecoder(bytes.NewReader(body))
 	dec.UseNumber()
 	if err := dec.Decode(out); err != nil {
 		BadRequest(w, err.Error())
 		return false
 	}
+
 	return true
+}
+
+func strictUnknownFieldsCheck(body []byte, target any) error {
+	if len(bytes.TrimSpace(body)) == 0 {
+		return nil
+	}
+
+	// Raw/plain config endpoint decodes body into string.
+	// Do not apply JSON strict check to string targets.
+	if _, ok := target.(*string); ok {
+		return nil
+	}
+
+	var raw any
+
+	dec := json.NewDecoder(bytes.NewReader(body))
+	dec.UseNumber()
+
+	if err := dec.Decode(&raw); err != nil {
+		return err
+	}
+
+	return checkUnknownFields(raw, reflect.TypeOf(target), "")
+}
+
+func checkUnknownFields(raw any, targetType reflect.Type, path string) error {
+	if targetType == nil {
+		return nil
+	}
+
+	for targetType.Kind() == reflect.Pointer {
+		targetType = targetType.Elem()
+	}
+
+	switch rawValue := raw.(type) {
+	case map[string]any:
+		switch targetType.Kind() {
+		case reflect.Struct:
+			allowed := jsonFieldNames(targetType)
+
+			for key, value := range rawValue {
+				fieldType, ok := allowed[key]
+				if !ok {
+					if path == "" {
+						return fmt.Errorf("unknown field %q", key)
+					}
+
+					return fmt.Errorf("unknown field %q at %s", key, path)
+				}
+
+				childPath := key
+				if path != "" {
+					childPath = path + "." + key
+				}
+
+				if err := checkUnknownFields(value, fieldType, childPath); err != nil {
+					return err
+				}
+			}
+
+		case reflect.Map:
+			elemType := targetType.Elem()
+
+			for key, value := range rawValue {
+				childPath := key
+				if path != "" {
+					childPath = path + "." + key
+				}
+
+				if err := checkUnknownFields(value, elemType, childPath); err != nil {
+					return err
+				}
+			}
+		}
+
+	case []any:
+		elemType := targetType
+
+		for elemType.Kind() == reflect.Pointer {
+			elemType = elemType.Elem()
+		}
+
+		if elemType.Kind() == reflect.Slice || elemType.Kind() == reflect.Array {
+			elemType = elemType.Elem()
+		}
+
+		for index, item := range rawValue {
+			childPath := fmt.Sprintf("%s[%d]", path, index)
+
+			if err := checkUnknownFields(item, elemType, childPath); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func jsonFieldNames(t reflect.Type) map[string]reflect.Type {
+	fields := make(map[string]reflect.Type)
+
+	for t.Kind() == reflect.Pointer {
+		t = t.Elem()
+	}
+
+	if t.Kind() != reflect.Struct {
+		return fields
+	}
+
+	for i := 0; i < t.NumField(); i++ {
+		field := t.Field(i)
+
+		// Skip unexported non-embedded fields.
+		if field.PkgPath != "" && !field.Anonymous {
+			continue
+		}
+
+		fieldType := field.Type
+		for fieldType.Kind() == reflect.Pointer {
+			fieldType = fieldType.Elem()
+		}
+
+		tag := field.Tag.Get("json")
+		name := strings.Split(tag, ",")[0]
+
+		if tag == "-" {
+			continue
+		}
+
+		// Embedded struct without explicit json name:
+		// type Resolver struct { ResolverBase }
+		// Need to flatten ResolverBase fields into parent object.
+		if field.Anonymous && (name == "" || name == field.Name) {
+			if fieldType.Kind() == reflect.Struct {
+				for embeddedName, embeddedType := range jsonFieldNames(fieldType) {
+					fields[embeddedName] = embeddedType
+				}
+				continue
+			}
+		}
+
+		if name == "" {
+			name = field.Name
+		}
+
+		fields[name] = field.Type
+	}
+
+	return fields
 }
 
 // Unprocessable writes a 422 Unprocessable Entity response with a cleaned


### PR DESCRIPTION
Hello!
Previously, JSON request bodies containing unknown fields could be accepted by the Data Plane API and silently decoded into client-native models with unsupported fields dropped.

This made it possible for users or automation pipelines to believe that a submitted configuration parameter was applied, while the field was actually ignored during decoding.

Add a strict pre-decode validation step in the JSON consumer. The request body is first decoded into a generic JSON structure and checked against the target Go model using reflection. If an unknown field is found, the API now returns a parsing error instead of silently dropping the field.

The check supports nested structs, embedded model structs, maps such as backend servers, and arrays. Plain text raw configuration endpoints are excluded from this validation.

This helps GitOps/CI pipelines fail early when a request contains misspelled or unsupported configuration parameters.

Please confirm your decision and add this functionality to the build. https://github.com/haproxytech/dataplaneapi/pull/405

Problem details. When requesting new edits, there will be no errors with such a request:
cat >/tmp/resolver_bad.json <<'EOF'
{
"name": "_dns_bad2",
"accepted_payload_size": 8192,
"parse-resolv-conf": false,
"resolve_retries": 3,
"timeout_retry": 1000,
"bad_unknown_param": "should_be_detected"
}
EOF

curl -i -u "$DP_USER:$DP_PASS"
-X POST
-H "Content-Type: application/json"
-H "Accept: application/json"
--data-binary @/tmp/resolver_bad.json
"$DP_URL/services/haproxy/configuration/resolvers?transaction_id=$TXID"

And in case of using pull req https://github.com/haproxytech/dataplaneapi/pull/405 :
HTTP/1.1 400 Bad Request
unknown field "bad_unknown_param"

Thanks.